### PR TITLE
Environment based command registration

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
+++ b/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
@@ -65,10 +65,14 @@ public class BedWarsPlugin extends JavaPlugin {
     public void registerCommands() {
         PaperCommandManager manager = new PaperCommandManager(this);
 
-        if (environment != Environment.DEVELOPMENT) {
+        if (environment != Environment.PRODUCTION) {
             manager.registerCommand(new CreateMapCommand()); // Command to create a new map
             manager.registerCommand(new OpenGuiCommand()); // Debug command. Will be removed when map configurations work fine
+
+            getComponentLogger().info(MiniMessage.miniMessage().deserialize("<green>Enabled <reset>map creation"));
+            return;
         }
+        getComponentLogger().info(MiniMessage.miniMessage().deserialize("<red>Disabled <reset>map creation"));
     }
 
     private void registerGuiIngredients() {


### PR DESCRIPTION
# Description

Diese PR fügt hinzu, dass Befehle basierend auf der Umgebung (nicht) registriert werden. So sind z.B. Befehle bzgl. der Erstellung von Maps nicht in `PRODUCTION` verfügbar. Nur `DEVELOPMENT` und `STAGING` enthalten diese.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes