### PR TITLE
Update configuration directory from 'config' to 'maps'

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/setup/map/LobbyMapSetup.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/LobbyMapSetup.java
@@ -59,7 +59,7 @@ public final class LobbyMapSetup implements MapSetup, Listener {
     @Override
     public void saveConfiguration() {
         try {
-            Path configDirPath = plugin.getDataFolder().toPath().resolve("config");
+            Path configDirPath = plugin.getDataFolder().toPath().resolve("maps");
             if (!Files.exists(configDirPath)) {
                 Files.createDirectory(configDirPath);
             }


### PR DESCRIPTION
# Description

Changed the configuration saving path to use a 'maps' directory instead of 'config'. This ensures that map-related configurations are stored in a more logically named folder, improving clarity and organization.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes