### PR TITLE
Update ArgumentTag to support locale-based translations

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/translation/PluginTranslationRegistry.java
+++ b/src/main/java/net/alphalightning/bedwars/translation/PluginTranslationRegistry.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.Nullable;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 public final class PluginTranslationRegistry implements TranslationRegistry {
 
@@ -55,7 +54,7 @@ public final class PluginTranslationRegistry implements TranslationRegistry {
         if (component.arguments().isEmpty()) {
             resulting = miniMessage.deserialize(miniString);
         } else {
-            resulting = miniMessage.deserialize(miniString, new ArgumentTag(component.arguments()));
+            resulting = miniMessage.deserialize(miniString, new ArgumentTag(component.arguments(), locale, delegate));
         }
 
         if (component.children().isEmpty()) {
@@ -80,12 +79,12 @@ public final class PluginTranslationRegistry implements TranslationRegistry {
         delegate.unregister(key);
     }
 
-    private record ArgumentTag(List<? extends ComponentLike> argumentComponents) implements TagResolver {
+    private record ArgumentTag(List<? extends ComponentLike> argumentComponents, Locale locale, TranslationRegistry registry) implements TagResolver {
         private static final String NAME = "argument";
         private static final String ALIAS = "arg";
 
         private ArgumentTag(final @NotNull List<? extends ComponentLike> argumentComponents) {
-            this.argumentComponents = Objects.requireNonNull(argumentComponents, "argumentComponents");
+            this(argumentComponents,  null, null);
         }
 
         @Override
@@ -95,7 +94,18 @@ public final class PluginTranslationRegistry implements TranslationRegistry {
 
             if (index < 0 || index >= argumentComponents.size()) throw ctx.newException("Invalid argument number", arguments);
 
-            return Tag.inserting(argumentComponents.get(index));
+            // Check if the argument is a TranslatableComponent and translate it
+            ComponentLike argument = argumentComponents.get(index);
+            if (argument instanceof TranslatableComponent translatable) {
+                Component translated = registry.translate(translatable, locale);
+
+                if (translated != null) {
+                    return Tag.inserting(translated);
+                }
+            }
+
+            // Default behavior
+            return Tag.inserting(argument);
         }
 
         @Override


### PR DESCRIPTION
# Description

Enhanced ArgumentTag to handle locale-aware translation of TranslatableComponents using the provided locale and translation registry. Introduced additional parameters to ArgumentTag and updated logic to translate arguments when applicable, ensuring better localization support.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes