### PR TITLE
Allow only one setup per player

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
+++ b/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
@@ -11,7 +11,7 @@ import net.alphalightning.bedwars.commands.CreateMapCommand;
 import net.alphalightning.bedwars.config.Configuration;
 import net.alphalightning.bedwars.config.Environment;
 import net.alphalightning.bedwars.manager.PlayerManager;
-import net.alphalightning.bedwars.provider.ConfigurationPlayerManager;
+import net.alphalightning.bedwars.manager.impl.ConfigurationPlayerManager;
 import net.alphalightning.bedwars.setup.ConfigurationType;
 import net.alphalightning.bedwars.setup.ui.item.BackgroundGuiItem;
 import net.alphalightning.bedwars.translation.PluginMiniMassageTranslator;
@@ -70,6 +70,8 @@ public class BedWarsPlugin extends JavaPlugin {
         PaperCommandManager manager = new PaperCommandManager(this);
 
         if (environment != Environment.PRODUCTION) {
+            manager.registerDependency(PlayerManager.class, setupPlayerManager);
+
             manager.registerCommand(new CreateMapCommand()); // Command to create a new map
 
             getComponentLogger().info(MiniMessage.miniMessage().deserialize("<green>Enabled <reset>map creation"));

--- a/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
+++ b/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
@@ -10,6 +10,9 @@ import de.eldoria.jacksonbukkit.JacksonPaper;
 import net.alphalightning.bedwars.commands.CreateMapCommand;
 import net.alphalightning.bedwars.config.Configuration;
 import net.alphalightning.bedwars.config.Environment;
+import net.alphalightning.bedwars.manager.PlayerManager;
+import net.alphalightning.bedwars.provider.ConfigurationPlayerManager;
+import net.alphalightning.bedwars.setup.ConfigurationType;
 import net.alphalightning.bedwars.setup.ui.item.BackgroundGuiItem;
 import net.alphalightning.bedwars.translation.PluginMiniMassageTranslator;
 import net.kyori.adventure.key.Key;
@@ -25,6 +28,7 @@ import java.util.ResourceBundle;
 
 public class BedWarsPlugin extends JavaPlugin {
 
+    private final PlayerManager<ConfigurationType> setupPlayerManager = new ConfigurationPlayerManager();
     private final ObjectMapper mapper = JsonMapper.builder()
             .addModule(JacksonPaper.builder().build())
             .enable(SerializationFeature.INDENT_OUTPUT) // Pretty printing
@@ -93,5 +97,9 @@ public class BedWarsPlugin extends JavaPlugin {
 
     public Configuration configuration() {
         return configuration;
+    }
+
+    public PlayerManager<ConfigurationType> setupPlayerManager() {
+        return setupPlayerManager;
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/commands/CreateMapCommand.java
+++ b/src/main/java/net/alphalightning/bedwars/commands/CreateMapCommand.java
@@ -3,8 +3,11 @@ package net.alphalightning.bedwars.commands;
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.*;
 import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.exception.AlreadyRegisteredException;
+import net.alphalightning.bedwars.manager.PlayerManager;
 import net.alphalightning.bedwars.setup.ConfigurationType;
 import net.alphalightning.bedwars.setup.Setup;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 
 @CommandAlias("createmap")
@@ -15,20 +18,35 @@ public class CreateMapCommand extends BaseCommand {
     @Dependency
     private BedWarsPlugin plugin;
 
+    @Dependency
+    private PlayerManager<ConfigurationType> playerManager;
+
     @Subcommand("lobby")
     public void onCreateLobby(Player player) {
-        Setup.mapBuilder(ConfigurationType.LOBBY)
-                .plugin(plugin)
-                .executor(player)
-                .build().start();
+        try {
+            playerManager.registerPlayer(player, ConfigurationType.LOBBY);
+            Setup.mapBuilder(ConfigurationType.LOBBY)
+                    .plugin(plugin)
+                    .executor(player)
+                    .build().start();
+
+        } catch (AlreadyRegisteredException exception) {
+            player.sendMessage(Component.translatable("error.setup.already-running"));
+        }
     }
 
     @Subcommand("gamemap")
     public void onCreateGameMap(Player player, @Name("mapName") String mapName) {
-        Setup.mapBuilder(ConfigurationType.MAP)
-                .plugin(plugin)
-                .executor(player)
-                .name(mapName)
-                .build().start();
+        try {
+            playerManager.registerPlayer(player, ConfigurationType.MAP);
+            Setup.mapBuilder(ConfigurationType.MAP)
+                    .plugin(plugin)
+                    .executor(player)
+                    .name(mapName)
+                    .build().start();
+
+        } catch (AlreadyRegisteredException exception) {
+            player.sendMessage(Component.translatable("error.setup.already-running"));
+        }
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/exception/AlreadyRegisteredException.java
+++ b/src/main/java/net/alphalightning/bedwars/exception/AlreadyRegisteredException.java
@@ -1,0 +1,4 @@
+package net.alphalightning.bedwars.exception;
+
+public class AlreadyRegisteredException extends BedWarsException {
+}

--- a/src/main/java/net/alphalightning/bedwars/exception/BedWarsException.java
+++ b/src/main/java/net/alphalightning/bedwars/exception/BedWarsException.java
@@ -1,0 +1,4 @@
+package net.alphalightning.bedwars.exception;
+
+public class BedWarsException extends Exception {
+}

--- a/src/main/java/net/alphalightning/bedwars/exception/NotRegisteredException.java
+++ b/src/main/java/net/alphalightning/bedwars/exception/NotRegisteredException.java
@@ -1,0 +1,4 @@
+package net.alphalightning.bedwars.exception;
+
+public class NotRegisteredException extends BedWarsException {
+}

--- a/src/main/java/net/alphalightning/bedwars/manager/PlayerManager.java
+++ b/src/main/java/net/alphalightning/bedwars/manager/PlayerManager.java
@@ -1,0 +1,21 @@
+package net.alphalightning.bedwars.manager;
+
+import net.alphalightning.bedwars.exception.AlreadyRegisteredException;
+import net.alphalightning.bedwars.exception.NotRegisteredException;
+import net.alphalightning.bedwars.provider.PlayerProvider;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface PlayerManager<T> {
+
+    @NotNull List<Player> registeredPlayers();
+
+    @NotNull PlayerProvider players();
+
+    void registerPlayer(Player player, T t) throws AlreadyRegisteredException;
+
+    void unregisterPlayer(Player player) throws NotRegisteredException;
+
+}

--- a/src/main/java/net/alphalightning/bedwars/manager/impl/ConfigurationPlayerManager.java
+++ b/src/main/java/net/alphalightning/bedwars/manager/impl/ConfigurationPlayerManager.java
@@ -1,8 +1,9 @@
-package net.alphalightning.bedwars.provider;
+package net.alphalightning.bedwars.manager.impl;
 
 import net.alphalightning.bedwars.exception.AlreadyRegisteredException;
 import net.alphalightning.bedwars.exception.NotRegisteredException;
 import net.alphalightning.bedwars.manager.PlayerManager;
+import net.alphalightning.bedwars.provider.PlayerProvider;
 import net.alphalightning.bedwars.provider.impl.ConfigurationPlayerProvider;
 import net.alphalightning.bedwars.setup.ConfigurationType;
 import org.bukkit.entity.Player;

--- a/src/main/java/net/alphalightning/bedwars/provider/ConfigurationPlayerManager.java
+++ b/src/main/java/net/alphalightning/bedwars/provider/ConfigurationPlayerManager.java
@@ -1,0 +1,64 @@
+package net.alphalightning.bedwars.provider;
+
+import net.alphalightning.bedwars.exception.AlreadyRegisteredException;
+import net.alphalightning.bedwars.exception.NotRegisteredException;
+import net.alphalightning.bedwars.manager.PlayerManager;
+import net.alphalightning.bedwars.provider.impl.ConfigurationPlayerProvider;
+import net.alphalightning.bedwars.setup.ConfigurationType;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Stream;
+
+public class ConfigurationPlayerManager implements PlayerManager<ConfigurationType> {
+
+    private final Queue<Player> lobbySetupPlayers = new ConcurrentLinkedQueue<>();
+    private final Queue<Player> gameMapSetupPlayers = new ConcurrentLinkedQueue<>();
+    private final PlayerProvider allPlayerProvider = new ConfigurationPlayerProvider(this::mergeQueues);
+
+    private @NotNull Stream<Player> mergeQueues() {
+        Queue<Player> merged = new ConcurrentLinkedQueue<>();
+        merged.addAll(lobbySetupPlayers);
+        merged.addAll(gameMapSetupPlayers);
+
+        return merged.stream();
+    }
+
+    @Override
+    public @NotNull List<Player> registeredPlayers() {
+        return this.mergeQueues().toList();
+    }
+
+    @Override
+    public @NotNull PlayerProvider players() {
+        return this.allPlayerProvider;
+    }
+
+    @Override
+    public void registerPlayer(Player player, ConfigurationType type) throws AlreadyRegisteredException {
+        if (this.allPlayerProvider.players().contains(player)) {
+            throw new AlreadyRegisteredException();
+        }
+
+        if (type == ConfigurationType.LOBBY) {
+            this.lobbySetupPlayers.add(player);
+            return;
+        }
+        gameMapSetupPlayers.add(player);
+    }
+
+    @Override
+    public void unregisterPlayer(Player player) throws NotRegisteredException {
+        if (!this.allPlayerProvider.players().contains(player)) {
+            throw new NotRegisteredException();
+        }
+        if (lobbySetupPlayers.contains(player)) {
+            lobbySetupPlayers.remove(player);
+            return;
+        }
+        gameMapSetupPlayers.remove(player);
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/provider/PlayerProvider.java
+++ b/src/main/java/net/alphalightning/bedwars/provider/PlayerProvider.java
@@ -1,0 +1,14 @@
+package net.alphalightning.bedwars.provider;
+
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public interface PlayerProvider {
+
+    @NotNull Collection<Player> players();
+
+    int count();
+
+}

--- a/src/main/java/net/alphalightning/bedwars/provider/impl/ConfigurationPlayerProvider.java
+++ b/src/main/java/net/alphalightning/bedwars/provider/impl/ConfigurationPlayerProvider.java
@@ -1,0 +1,28 @@
+package net.alphalightning.bedwars.provider.impl;
+
+import net.alphalightning.bedwars.provider.PlayerProvider;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public class ConfigurationPlayerProvider implements PlayerProvider {
+
+    private final Supplier<Stream<Player>> playerSupplier;
+
+    public ConfigurationPlayerProvider(Supplier<Stream<Player>> playerSupplier) {
+        this.playerSupplier = playerSupplier;
+    }
+
+    @Override
+    public @NotNull Collection<Player> players() {
+        return this.playerSupplier.get().toList();
+    }
+
+    @Override
+    public int count() {
+        return (int) this.playerSupplier.get().count();
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/CompleteSetupStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/CompleteSetupStage.java
@@ -1,6 +1,7 @@
 package net.alphalightning.bedwars.setup.map.stages;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.exception.NotRegisteredException;
 import net.alphalightning.bedwars.feedback.Feedback;
 import net.alphalightning.bedwars.setup.map.MapSetup;
 import net.kyori.adventure.text.Component;
@@ -21,5 +22,15 @@ public class CompleteSetupStage extends Stage {
     public void run() {
         player.sendMessage(Component.translatable(isLobbySetup ? "lobbysetup.finish" : "mapsetup.finish", Component.text(fileName)));
         Feedback.complete(player);
+
+        try {
+            super.playerManager.unregisterPlayer(player);
+
+        } catch (NotRegisteredException exception) {
+            player.sendMessage(Component.translatable("error.setup.none"));
+
+        } finally {
+            invalidate();
+        }
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/CompleteSetupStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/CompleteSetupStage.java
@@ -1,7 +1,6 @@
 package net.alphalightning.bedwars.setup.map.stages;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
-import net.alphalightning.bedwars.exception.NotRegisteredException;
 import net.alphalightning.bedwars.feedback.Feedback;
 import net.alphalightning.bedwars.setup.map.MapSetup;
 import net.kyori.adventure.text.Component;
@@ -23,14 +22,6 @@ public class CompleteSetupStage extends Stage {
         player.sendMessage(Component.translatable(isLobbySetup ? "lobbysetup.finish" : "mapsetup.finish", Component.text(fileName)));
         Feedback.complete(player);
 
-        try {
-            super.playerManager.unregisterPlayer(player);
-
-        } catch (NotRegisteredException exception) {
-            player.sendMessage(Component.translatable("error.setup.none"));
-
-        } finally {
-            invalidate();
-        }
+        invalidate();
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/Stage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/Stage.java
@@ -1,21 +1,28 @@
 package net.alphalightning.bedwars.setup.map.stages;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.exception.NotRegisteredException;
+import net.alphalightning.bedwars.manager.PlayerManager;
+import net.alphalightning.bedwars.setup.ConfigurationType;
 import net.alphalightning.bedwars.setup.map.MapSetup;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class Stage implements Listener {
 
+    protected final PlayerManager<ConfigurationType> playerManager;
     protected final BedWarsPlugin plugin;
     protected final MapSetup setup;
     protected Player player;
 
-    public Stage(BedWarsPlugin plugin, Player player, MapSetup setup) {
+    public Stage(@NotNull BedWarsPlugin plugin, Player player, MapSetup setup) {
         this.plugin = plugin;
         this.player = player;
         this.setup = setup;
+        this.playerManager = plugin.setupPlayerManager();
 
         Bukkit.getPluginManager().registerEvents(this, plugin);
     }
@@ -29,7 +36,15 @@ public abstract class Stage implements Listener {
     }
 
     public void invalidate() {
-        player = null;
+        try {
+            playerManager.unregisterPlayer(player);
+
+        } catch (NotRegisteredException exception) {
+            player.sendMessage(Component.translatable("error.setup.none"));
+
+        } finally {
+            player = null;
+        }
     }
 
     public abstract void run();

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -28,6 +28,9 @@ team.purple = <dark_purple>Team Lila
 team.magenta = <color:#ff24fb>Team Magenta
 team.pink = <color:#ff6ef8>Team Pink
 
+error.setup.already-running = <red>Du durchläufst bereits ein Setup!
+error.setup.none = <red>Du durchläufst derzeit kein Setup.
+
 # Nachrichten, die zum Lobbysetup gehören
 lobbysetup.start = <gray>Das Lobbysetup wurde gestartet. Bitte folge den Anweisungen. Nur wenn das Setup vollständig durchlaufen wurde ist die Lobby konfiguriert und nutzbar.
 lobbysetup.finish = <gray>Das Lobbysetup wurde <green>erfolgreich abgeschlossen<gray>. Du kannst nun die Datei <yellow><arg:0> <gray>in die Produktion übertragen.


### PR DESCRIPTION
# Description

Diese PR führt ein, dass pro Spieler nur ein Setup gleichzeitig durchlaufen werden kann.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes