### PR TITLE
Render bed visuals

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
@@ -8,6 +8,8 @@ import net.alphalightning.bedwars.setup.map.jackson.Team;
 import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
+import net.alphalightning.bedwars.setup.visual.impl.MultiBlockRenderer;
+import net.alphalightning.bedwars.setup.visual.impl.MultiBlockVisualisation;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -107,6 +109,7 @@ public class BedConfigurationStage extends Stage implements TeamConfiguration, L
 
         team.bedTopHalf(topHalf);
 
+        new MultiBlockRenderer(plugin, List.of(topHalf.getBlock(), bottom.getBlock())).render(new MultiBlockVisualisation(team.color()));
         player.sendMessage(Component.translatable("mapsetup.stage.14.name.success", teamName));
         Feedback.success(player);
     }

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
@@ -113,7 +113,7 @@ public class BedConfigurationStage extends Stage implements TeamConfiguration, L
         team.bedTopHalf(topHalf);
 
         new MultiBlockRenderer(plugin, List.of(topHalf.getBlock(), bottom.getBlock())).render(new MultiBlockVisualisation(team.color()));
-        new FakeBlockRenderer(plugin, bottom).render(new FakeBlockVisualisation(coloredBed()));
+        new FakeBlockRenderer(plugin, topHalf).render(new FakeBlockVisualisation(coloredBed())); // "BED" is top half
 
         player.sendMessage(Component.translatable("mapsetup.stage.14.name.success", teamName));
         Feedback.success(player);

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
@@ -113,7 +113,7 @@ public class BedConfigurationStage extends Stage implements TeamConfiguration, L
         team.bedTopHalf(topHalf);
 
         new MultiBlockRenderer(plugin, List.of(topHalf.getBlock(), bottom.getBlock())).render(new MultiBlockVisualisation(team.color()));
-        new FakeBlockRenderer(plugin, bottom).render(new FakeBlockVisualisation(Material.RED_BED));
+        new FakeBlockRenderer(plugin, bottom).render(new FakeBlockVisualisation(coloredBed()));
 
         player.sendMessage(Component.translatable("mapsetup.stage.14.name.success", teamName));
         Feedback.success(player);
@@ -131,5 +131,27 @@ public class BedConfigurationStage extends Stage implements TeamConfiguration, L
             }
         }
         return top;
+    }
+
+    private Material coloredBed() {
+        return switch (team.color()) { // Colors are default hex encoded int values
+            case 0xffffff -> Material.WHITE_BED;
+            case 0xaaaaaa -> Material.LIGHT_GRAY_BED;
+            case 0x555555 -> Material.GRAY_BED;
+            case 0x000000 -> Material.BLACK_BED;
+            case 0x783d0c -> Material.BROWN_BED;
+            case 0xff5555 -> Material.RED_BED;
+            case 0xff8800 -> Material.ORANGE_BED;
+            case 0xffff55 -> Material.YELLOW_BED;
+            case 0x55ff55 -> Material.LIME_BED;
+            case 0x00aa00 -> Material.GREEN_BED;
+            case 0x00aaaa -> Material.CYAN_BED;
+            case 0xa3e5ff -> Material.LIGHT_BLUE_BED;
+            case 0x5555ff -> Material.BLUE_BED;
+            case 0xaa00aa -> Material.PURPLE_BED;
+            case 0xff24fb -> Material.MAGENTA_BED;
+            case 0xff6ef8 -> Material.PINK_BED;
+            default -> Material.AIR;
+        };
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
@@ -8,12 +8,15 @@ import net.alphalightning.bedwars.setup.map.jackson.Team;
 import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
+import net.alphalightning.bedwars.setup.visual.impl.FakeBlockRenderer;
+import net.alphalightning.bedwars.setup.visual.impl.FakeBlockVisualisation;
 import net.alphalightning.bedwars.setup.visual.impl.MultiBlockRenderer;
 import net.alphalightning.bedwars.setup.visual.impl.MultiBlockVisualisation;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
@@ -110,6 +113,8 @@ public class BedConfigurationStage extends Stage implements TeamConfiguration, L
         team.bedTopHalf(topHalf);
 
         new MultiBlockRenderer(plugin, List.of(topHalf.getBlock(), bottom.getBlock())).render(new MultiBlockVisualisation(team.color()));
+        new FakeBlockRenderer(plugin, bottom).render(new FakeBlockVisualisation(Material.RED_BED));
+
         player.sendMessage(Component.translatable("mapsetup.stage.14.name.success", teamName));
         Feedback.success(player);
     }

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamChestConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamChestConfigurationStage.java
@@ -16,6 +16,7 @@ import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
@@ -87,7 +88,7 @@ public class TeamChestConfigurationStage extends Stage implements TeamConfigurat
 
         team.chest(withOffset);
         new BlockEdgeRenderer(plugin, withOffset.getBlock()).render(new BlockEdgeVisualisation(team.color()));
-        new FakeBlockRenderer(plugin, withOffset).render(new FakeBlockVisualisation());
+        new FakeBlockRenderer(plugin, withOffset).render(new FakeBlockVisualisation(Material.CHEST));
 
         player.sendMessage(Component.translatable("mapsetup.stage.11.name.success", teamName));
         Feedback.success(player);

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/FakeBlockVisualisation.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/FakeBlockVisualisation.java
@@ -12,6 +12,12 @@ import org.jetbrains.annotations.NotNull;
 
 public class FakeBlockVisualisation implements Visualisation<Location> {
 
+    private final Material material;
+
+    public FakeBlockVisualisation(Material material) {
+        this.material = material;
+    }
+
     @Override
     public void show(@NotNull Location location) {
         final Location blockLocation = location.toBlockLocation();
@@ -21,7 +27,7 @@ public class FakeBlockVisualisation implements Visualisation<Location> {
             final BlockDisplay blockDisplay = (BlockDisplay) entity;
             final Location displayLocation = blockLocation.addRotation(location.getYaw() * -1, location.getPitch() * -1);
 
-            blockDisplay.setBlock(Bukkit.createBlockData(Material.CHEST));
+            blockDisplay.setBlock(Bukkit.createBlockData(material));
             blockDisplay.teleport(displayLocation);
         });
     }


### PR DESCRIPTION
# Description

Diese PR fügt visuelle Effekte bei der Konfiguration der Betten hinzu. Die BoundingBox der beiden Blöcke wird mit Partikeln umrandet und ein fake Bett in der jeweiligen Teamfarbe wird gespawnt.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes