### PR TITLE
Particle cloud at min./max. buildheight

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
@@ -9,9 +9,9 @@ import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
 import net.alphalightning.bedwars.setup.visual.impl.FakeBlockRenderer;
-import net.alphalightning.bedwars.setup.visual.impl.FakeBlockVisualisation;
+import net.alphalightning.bedwars.setup.visual.impl.FakeBlockVisualization;
 import net.alphalightning.bedwars.setup.visual.impl.MultiBlockRenderer;
-import net.alphalightning.bedwars.setup.visual.impl.MultiBlockVisualisation;
+import net.alphalightning.bedwars.setup.visual.impl.MultiBlockVisualization;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -112,8 +112,8 @@ public class BedConfigurationStage extends Stage implements TeamConfiguration, L
 
         team.bedTopHalf(topHalf);
 
-        new MultiBlockRenderer(plugin, List.of(topHalf.getBlock(), bottom.getBlock())).render(new MultiBlockVisualisation(team.color()));
-        new FakeBlockRenderer(plugin, topHalf).render(new FakeBlockVisualisation(coloredBed())); // "BED" is top half
+        new MultiBlockRenderer(plugin, List.of(topHalf.getBlock(), bottom.getBlock())).render(new MultiBlockVisualization(team.color()));
+        new FakeBlockRenderer(plugin, topHalf).render(new FakeBlockVisualization(coloredBed())); // "BED" is top half
 
         player.sendMessage(Component.translatable("mapsetup.stage.14.name.success", teamName));
         Feedback.success(player);

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/MaxBuildHeightConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/MaxBuildHeightConfigurationStage.java
@@ -7,6 +7,8 @@ import net.alphalightning.bedwars.setup.map.GameMapSetup;
 import net.alphalightning.bedwars.setup.map.MapSetup;
 import net.alphalightning.bedwars.setup.map.stages.HeightConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
+import net.alphalightning.bedwars.setup.visual.impl.HeightRenderer;
+import net.alphalightning.bedwars.setup.visual.impl.HeightVisualization;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -59,6 +61,7 @@ public class MaxBuildHeightConfigurationStage extends Stage implements HeightCon
             return;
         }
 
+        new HeightRenderer(plugin, player).render(new HeightVisualization(buildHeight));
         player.sendMessage(Component.translatable("mapsetup.stage.4.success", Component.text(buildHeight)));
         Feedback.success(player);
 

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/MinBuildHeightConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/MinBuildHeightConfigurationStage.java
@@ -7,6 +7,8 @@ import net.alphalightning.bedwars.setup.map.GameMapSetup;
 import net.alphalightning.bedwars.setup.map.MapSetup;
 import net.alphalightning.bedwars.setup.map.stages.HeightConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
+import net.alphalightning.bedwars.setup.visual.impl.HeightRenderer;
+import net.alphalightning.bedwars.setup.visual.impl.HeightVisualization;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -68,6 +70,7 @@ public class MinBuildHeightConfigurationStage extends Stage implements HeightCon
             return;
         }
 
+        new HeightRenderer(plugin, player).render(new HeightVisualization(buildHeight));
         player.sendMessage(Component.translatable("mapsetup.stage.5.success", Component.text(buildHeight)));
         Feedback.success(player);
 

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamChestConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamChestConfigurationStage.java
@@ -9,9 +9,9 @@ import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
 import net.alphalightning.bedwars.setup.visual.impl.BlockEdgeRenderer;
-import net.alphalightning.bedwars.setup.visual.impl.BlockEdgeVisualisation;
+import net.alphalightning.bedwars.setup.visual.impl.BlockEdgeVisualization;
 import net.alphalightning.bedwars.setup.visual.impl.FakeBlockRenderer;
-import net.alphalightning.bedwars.setup.visual.impl.FakeBlockVisualisation;
+import net.alphalightning.bedwars.setup.visual.impl.FakeBlockVisualization;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -87,8 +87,8 @@ public class TeamChestConfigurationStage extends Stage implements TeamConfigurat
         final Location withOffset = location.add(OFFSET);
 
         team.chest(withOffset);
-        new BlockEdgeRenderer(plugin, withOffset.getBlock()).render(new BlockEdgeVisualisation(team.color()));
-        new FakeBlockRenderer(plugin, withOffset).render(new FakeBlockVisualisation(Material.CHEST));
+        new BlockEdgeRenderer(plugin, withOffset.getBlock()).render(new BlockEdgeVisualization(team.color()));
+        new FakeBlockRenderer(plugin, withOffset).render(new FakeBlockVisualization(Material.CHEST));
 
         player.sendMessage(Component.translatable("mapsetup.stage.11.name.success", teamName));
         Feedback.success(player);

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamSpawnpointConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamSpawnpointConfigurationStage.java
@@ -9,9 +9,9 @@ import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
 import net.alphalightning.bedwars.setup.visual.impl.MultiBlockRenderer;
-import net.alphalightning.bedwars.setup.visual.impl.MultiBlockVisualisation;
+import net.alphalightning.bedwars.setup.visual.impl.MultiBlockVisualization;
 import net.alphalightning.bedwars.setup.visual.impl.SingleLineRenderer;
-import net.alphalightning.bedwars.setup.visual.impl.SingleLineVisualisation;
+import net.alphalightning.bedwars.setup.visual.impl.SingleLineVisualization;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -88,8 +88,8 @@ public class TeamSpawnpointConfigurationStage extends Stage implements TeamConfi
 
         if (!event.isSneaking()) {
             new MultiBlockRenderer(plugin, List.of(withOffset.getBlock(), withOffset.add(0, 1, 0).getBlock()))
-                    .render(new MultiBlockVisualisation(team.color()));
-            new SingleLineRenderer(plugin, player).render(new SingleLineVisualisation(player));
+                    .render(new MultiBlockVisualization(team.color()));
+            new SingleLineRenderer(plugin, player).render(new SingleLineVisualization(player));
         }
 
         team.spawnpoint(withOffset);

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/BlockVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/BlockVisualization.java
@@ -8,7 +8,7 @@ import org.bukkit.World;
 import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
 
-public interface BlockVisualisation<T> extends Visualisation<T> {
+public interface BlockVisualization<T> extends Visualization<T> {
 
     default void visualizeBoundingBox(@NotNull World world, @NotNull BoundingBox boundingBox, int color) {
         final double minX = boundingBox.getMinX();

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/UnboundTeamVisuals.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/UnboundTeamVisuals.java
@@ -2,9 +2,9 @@ package net.alphalightning.bedwars.setup.visual;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.setup.visual.impl.MultiBlockRenderer;
-import net.alphalightning.bedwars.setup.visual.impl.MultiBlockVisualisation;
+import net.alphalightning.bedwars.setup.visual.impl.MultiBlockVisualization;
 import net.alphalightning.bedwars.setup.visual.impl.SingleLineRenderer;
-import net.alphalightning.bedwars.setup.visual.impl.SingleLineVisualisation;
+import net.alphalightning.bedwars.setup.visual.impl.SingleLineVisualization;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -15,8 +15,8 @@ public interface UnboundTeamVisuals {
 
     static void renderSpawnpoint(BedWarsPlugin plugin, Player player, @NotNull Location withOffset) {
         new MultiBlockRenderer(plugin, List.of(withOffset.getBlock(), withOffset.add(0, 1, 0).getBlock()))
-                .render(new MultiBlockVisualisation(0xecb8f5));
-        new SingleLineRenderer(plugin, player).render(new SingleLineVisualisation(player));
+                .render(new MultiBlockVisualization(0xecb8f5));
+        new SingleLineRenderer(plugin, player).render(new SingleLineVisualization(player));
     }
 
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/Visualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/Visualization.java
@@ -2,7 +2,7 @@ package net.alphalightning.bedwars.setup.visual;
 
 import org.jetbrains.annotations.NotNull;
 
-public interface Visualisation<T>  extends VisualisationConfiguration {
+public interface Visualization<T>  extends VisualizationConfiguration {
 
     void show(@NotNull T t);
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/VisualizationConfiguration.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/VisualizationConfiguration.java
@@ -1,6 +1,6 @@
 package net.alphalightning.bedwars.setup.visual;
 
-public interface VisualisationConfiguration {
+public interface VisualizationConfiguration {
 
     double STEP = 0.15D;
     float SIZE = 0.75F;

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/VisualizationRenderer.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/VisualizationRenderer.java
@@ -3,7 +3,7 @@ package net.alphalightning.bedwars.setup.visual;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 
-public interface VisualisationRenderer<T extends Visualisation<?>> {
+public interface VisualizationRenderer<T extends Visualization<?>> {
 
     @NotNull BukkitTask render(@NotNull T visualisation);
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/BlockEdgeRenderer.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/BlockEdgeRenderer.java
@@ -1,14 +1,14 @@
 package net.alphalightning.bedwars.setup.visual.impl;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
-import net.alphalightning.bedwars.setup.visual.VisualisationRenderer;
+import net.alphalightning.bedwars.setup.visual.VisualizationRenderer;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 
 
-public class BlockEdgeRenderer implements VisualisationRenderer<BlockEdgeVisualisation> {
+public class BlockEdgeRenderer implements VisualizationRenderer<BlockEdgeVisualization> {
 
     private final BedWarsPlugin plugin;
     private final Block block;
@@ -19,7 +19,7 @@ public class BlockEdgeRenderer implements VisualisationRenderer<BlockEdgeVisuali
     }
 
     @Override
-    public @NotNull BukkitTask render(@NotNull BlockEdgeVisualisation visualisation) {
+    public @NotNull BukkitTask render(@NotNull BlockEdgeVisualization visualisation) {
         return Bukkit.getScheduler().runTaskTimer(plugin, () -> visualisation.show(block), 0L, 5L);
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/BlockEdgeVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/BlockEdgeVisualization.java
@@ -1,15 +1,15 @@
 package net.alphalightning.bedwars.setup.visual.impl;
 
-import net.alphalightning.bedwars.setup.visual.BlockVisualisation;
+import net.alphalightning.bedwars.setup.visual.BlockVisualization;
 import org.bukkit.block.Block;
 import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
 
-public class BlockEdgeVisualisation implements BlockVisualisation<Block> {
+public class BlockEdgeVisualization implements BlockVisualization<Block> {
 
     private final int color;
 
-    public BlockEdgeVisualisation(int color) {
+    public BlockEdgeVisualization(int color) {
         this.color = color;
     }
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/FakeBlockRenderer.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/FakeBlockRenderer.java
@@ -1,13 +1,13 @@
 package net.alphalightning.bedwars.setup.visual.impl;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
-import net.alphalightning.bedwars.setup.visual.VisualisationRenderer;
+import net.alphalightning.bedwars.setup.visual.VisualizationRenderer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 
-public class FakeBlockRenderer implements VisualisationRenderer<FakeBlockVisualisation> {
+public class FakeBlockRenderer implements VisualizationRenderer<FakeBlockVisualization> {
 
     private final BedWarsPlugin plugin;
     private final Location location;
@@ -18,7 +18,7 @@ public class FakeBlockRenderer implements VisualisationRenderer<FakeBlockVisuali
     }
 
     @Override
-    public @NotNull BukkitTask render(@NotNull FakeBlockVisualisation visualisation) {
+    public @NotNull BukkitTask render(@NotNull FakeBlockVisualization visualisation) {
         return Bukkit.getScheduler().runTask(plugin, () -> visualisation.show(location));
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/FakeBlockVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/FakeBlockVisualization.java
@@ -1,6 +1,6 @@
 package net.alphalightning.bedwars.setup.visual.impl;
 
-import net.alphalightning.bedwars.setup.visual.Visualisation;
+import net.alphalightning.bedwars.setup.visual.Visualization;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -10,11 +10,11 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.jetbrains.annotations.NotNull;
 
-public class FakeBlockVisualisation implements Visualisation<Location> {
+public class FakeBlockVisualization implements Visualization<Location> {
 
     private final Material material;
 
-    public FakeBlockVisualisation(Material material) {
+    public FakeBlockVisualization(Material material) {
         this.material = material;
     }
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightRenderer.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightRenderer.java
@@ -1,0 +1,24 @@
+package net.alphalightning.bedwars.setup.visual.impl;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.setup.visual.VisualizationRenderer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+public class HeightRenderer implements VisualizationRenderer<HeightVisualization> {
+
+    private final BedWarsPlugin plugin;
+    private final Player player;
+
+    public HeightRenderer(BedWarsPlugin plugin, Player player) {
+        this.plugin = plugin;
+        this.player = player;
+    }
+
+    @Override
+    public @NotNull BukkitTask render(@NotNull HeightVisualization visualisation) {
+        return Bukkit.getScheduler().runTaskTimer(plugin, () -> visualisation.show(player.getLocation()), 0L, 5L);
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
@@ -11,7 +11,7 @@ public class HeightVisualization implements Visualization<Location> {
 
     private static final double RADIUS = 7.5D;
     private static final double SPAWN_DISTANCE = 5.0D;
-    private static final int PARTICLE_COUNT = 40;
+    private static final int PARTICLE_COUNT = 60;
 
     private final double height;
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 public class HeightVisualization implements Visualization<Location> {
 
     private static final double RADIUS = 7.5D;
-    private static final double SPAWN_DISTANCE = 5.0D;
+    private static final double SPAWN_DISTANCE = 10D;
     private static final int PARTICLE_COUNT = 150;
 
     private final double height;

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
@@ -1,0 +1,46 @@
+package net.alphalightning.bedwars.setup.visual.impl;
+
+import com.destroystokyo.paper.ParticleBuilder;
+import net.alphalightning.bedwars.setup.visual.Visualization;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.jetbrains.annotations.NotNull;
+
+public class HeightVisualization implements Visualization<Location> {
+
+    private static final double RADIUS = 5.0D;
+    private static final double SPAWN_DISTANCE = 5.0D;
+    private static final int PARTICLE_COUNT = 20;
+
+    private final double height;
+
+    public HeightVisualization(double height) {
+        this.height = height;
+    }
+
+    @Override
+    public void show(@NotNull Location location) {
+        if (Math.abs(location.getY() - height) > SPAWN_DISTANCE) { // Check if player is near the target height
+            return;
+        }
+
+        for (int i = 0; i < PARTICLE_COUNT; i++) {
+            // Random angles and distances in radius
+            double angle = Math.random() * 2 * Math.PI;
+            double distance = Math.random() * RADIUS;
+            double offsetX = Math.cos(angle) * distance;
+            double offsetZ = Math.sin(angle) * distance;
+
+            Location point = new Location(location.getWorld(), location.x() + offsetX, height, location.z() + offsetZ);
+            drawParticle(point);
+        }
+    }
+
+    private void drawParticle(Location location) {
+        new ParticleBuilder(Particle.DUST)
+                .location(location)
+                .color(Color.RED, SIZE)
+                .spawn();
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
@@ -11,7 +11,7 @@ public class HeightVisualization implements Visualization<Location> {
 
     private static final double RADIUS = 7.5D;
     private static final double SPAWN_DISTANCE = 5.0D;
-    private static final int PARTICLE_COUNT = 80;
+    private static final int PARTICLE_COUNT = 150;
 
     private final double height;
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
@@ -9,9 +9,9 @@ import org.jetbrains.annotations.NotNull;
 
 public class HeightVisualization implements Visualization<Location> {
 
-    private static final double RADIUS = 5.0D;
+    private static final double RADIUS = 7.5D;
     private static final double SPAWN_DISTANCE = 5.0D;
-    private static final int PARTICLE_COUNT = 20;
+    private static final int PARTICLE_COUNT = 40;
 
     private final double height;
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/HeightVisualization.java
@@ -11,7 +11,7 @@ public class HeightVisualization implements Visualization<Location> {
 
     private static final double RADIUS = 7.5D;
     private static final double SPAWN_DISTANCE = 5.0D;
-    private static final int PARTICLE_COUNT = 60;
+    private static final int PARTICLE_COUNT = 80;
 
     private final double height;
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/MultiBlockRenderer.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/MultiBlockRenderer.java
@@ -1,7 +1,7 @@
 package net.alphalightning.bedwars.setup.visual.impl;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
-import net.alphalightning.bedwars.setup.visual.VisualisationRenderer;
+import net.alphalightning.bedwars.setup.visual.VisualizationRenderer;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.scheduler.BukkitTask;
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public class MultiBlockRenderer implements VisualisationRenderer<MultiBlockVisualisation> {
+public class MultiBlockRenderer implements VisualizationRenderer<MultiBlockVisualization> {
 
     private final BedWarsPlugin plugin;
     private final List<Block> blocks;
@@ -20,7 +20,7 @@ public class MultiBlockRenderer implements VisualisationRenderer<MultiBlockVisua
     }
 
     @Override
-    public @NotNull BukkitTask render(@NotNull MultiBlockVisualisation visualisation) {
+    public @NotNull BukkitTask render(@NotNull MultiBlockVisualization visualisation) {
         return Bukkit.getScheduler().runTaskTimer(this.plugin, () -> visualisation.show(this.blocks), 0L, 5L);
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/MultiBlockVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/MultiBlockVisualization.java
@@ -1,17 +1,17 @@
 package net.alphalightning.bedwars.setup.visual.impl;
 
-import net.alphalightning.bedwars.setup.visual.BlockVisualisation;
+import net.alphalightning.bedwars.setup.visual.BlockVisualization;
 import org.bukkit.block.Block;
 import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public class MultiBlockVisualisation implements BlockVisualisation<List<Block>> {
+public class MultiBlockVisualization implements BlockVisualization<List<Block>> {
 
     private final int color;
 
-    public MultiBlockVisualisation(int color) {
+    public MultiBlockVisualization(int color) {
         this.color = color;
     }
 

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/SingleLineRenderer.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/SingleLineRenderer.java
@@ -1,14 +1,14 @@
 package net.alphalightning.bedwars.setup.visual.impl;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
-import net.alphalightning.bedwars.setup.visual.VisualisationRenderer;
+import net.alphalightning.bedwars.setup.visual.VisualizationRenderer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 
-public class SingleLineRenderer implements VisualisationRenderer<SingleLineVisualisation> {
+public class SingleLineRenderer implements VisualizationRenderer<SingleLineVisualization> {
 
     private final BedWarsPlugin plugin;
     private final Player player;
@@ -19,7 +19,7 @@ public class SingleLineRenderer implements VisualisationRenderer<SingleLineVisua
     }
 
     @Override
-    public @NotNull BukkitTask render(@NotNull SingleLineVisualisation visualisation) {
+    public @NotNull BukkitTask render(@NotNull SingleLineVisualization visualisation) {
         final Location start = this.player.getEyeLocation();
         return Bukkit.getScheduler().runTaskTimer(plugin, () -> visualisation.show(start), 0L, 5L);
     }

--- a/src/main/java/net/alphalightning/bedwars/setup/visual/impl/SingleLineVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/visual/impl/SingleLineVisualization.java
@@ -1,7 +1,7 @@
 package net.alphalightning.bedwars.setup.visual.impl;
 
 import com.destroystokyo.paper.ParticleBuilder;
-import net.alphalightning.bedwars.setup.visual.Visualisation;
+import net.alphalightning.bedwars.setup.visual.Visualization;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -9,7 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
-public record SingleLineVisualisation(Player player) implements Visualisation<Location> {
+public record SingleLineVisualization(Player player) implements Visualization<Location> {
 
     private static final int LINE_LENGTH = 5;
     private static final int COLOR = 0xff5286;


### PR DESCRIPTION
# Description

Diese PR fügt eine Partikelwolke auf Höhe der definierten maximalen bzw. minimalen Bauhöhe, wenn der Spieler sich maximal 10 Blöcke von diesen entfernt aufhält, hinzu.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes