### PR TITLE
Ignore merge commits in time tracking workflow

### DIFF
--- a/.github/workflows/time-tracking.yml
+++ b/.github/workflows/time-tracking.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update_jira-time:
+    if: "!startsWith(github.event.head_commit.message, 'Merge')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -27,9 +28,9 @@ jobs:
           HOURS=$(echo "${{ env.message }}" | grep -oP '\d+(?=\s*hour(s)?)' || echo "0")
           MINUTES=$(echo "${{ env.message }}" | grep -oP '\d+(?=\s*min(ute)?s?)' || echo "0")
           SECONDS=$(echo "${{ env.message }}" | grep -oP '\d+(?=\s*second(s)?)' || echo "0")
-  
+          
           TOTAL_SECONDS=$((HOURS * 3600 + MINUTES * 60 + SECONDS))
-      
+          
           echo "Extracted time: ${TOTAL_SECONDS}s (${HOURS}h ${MINUTES}m ${SECONDS}s)"
           echo "total_time=${TOTAL_SECONDS}" >> $GITHUB_ENV
 


### PR DESCRIPTION
Took 5 minutes

# Description

Diese PR fügt hinzu, dass Merge-Commits nicht den Time Tracking Workflow triggern.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes