### PR TITLE
Render fake Diamond-/Emerald spawner in gamemap setup

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/feedback/visual/impl/TeamLootSpawnerRenderer.java
+++ b/src/main/java/net/alphalightning/bedwars/feedback/visual/impl/TeamLootSpawnerRenderer.java
@@ -7,18 +7,18 @@ import org.bukkit.Location;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 
-public class SpawnerRenderer implements VisualizationRenderer<SpawnerVisualization> {
+public class TeamLootSpawnerRenderer implements VisualizationRenderer<TeamLootspawnerVisualization> {
 
     private final BedWarsPlugin plugin;
     private final Location location;
 
-    public SpawnerRenderer(BedWarsPlugin plugin, Location location) {
+    public TeamLootSpawnerRenderer(BedWarsPlugin plugin, Location location) {
         this.plugin = plugin;
         this.location = location;
     }
 
     @Override
-    public @NotNull BukkitTask render(@NotNull SpawnerVisualization visualisation) {
+    public @NotNull BukkitTask render(@NotNull TeamLootspawnerVisualization visualisation) {
         return Bukkit.getScheduler().runTaskTimer(this.plugin, () -> visualisation.show(this.location), 0L, 10L);
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/feedback/visual/impl/TeamLootspawnerVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/feedback/visual/impl/TeamLootspawnerVisualization.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashSet;
 import java.util.Set;
 
-public class SpawnerVisualization implements Visualization<Location> {
+public class TeamLootspawnerVisualization implements Visualization<Location> {
 
     private final BedWarsPlugin plugin;
 
@@ -23,7 +23,7 @@ public class SpawnerVisualization implements Visualization<Location> {
     private final Set<Item> spawnedItems = new HashSet<>();
     private int counter;
 
-    public SpawnerVisualization(BedWarsPlugin plugin, GameMapSetup gameMapSetup) {
+    public TeamLootspawnerVisualization(BedWarsPlugin plugin, GameMapSetup gameMapSetup) {
         this.plugin = plugin;
         this.gameMapSetup = gameMapSetup;
     }

--- a/src/main/java/net/alphalightning/bedwars/feedback/visual/impl/ValuableSpawnerRenderer.java
+++ b/src/main/java/net/alphalightning/bedwars/feedback/visual/impl/ValuableSpawnerRenderer.java
@@ -1,0 +1,24 @@
+package net.alphalightning.bedwars.feedback.visual.impl;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.feedback.visual.VisualizationRenderer;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+public class ValuableSpawnerRenderer implements VisualizationRenderer<ValuableSpawnerVisualization> {
+
+    private final BedWarsPlugin plugin;
+    private final Location location;
+
+    public ValuableSpawnerRenderer(BedWarsPlugin plugin, Location location) {
+        this.plugin = plugin;
+        this.location = location;
+    }
+
+    @Override
+    public @NotNull BukkitTask render(@NotNull ValuableSpawnerVisualization visualisation) {
+        return Bukkit.getScheduler().runTaskTimer(this.plugin, () -> visualisation.show(this.location), 0L, 10L);
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/feedback/visual/impl/ValuableSpawnerVisualization.java
+++ b/src/main/java/net/alphalightning/bedwars/feedback/visual/impl/ValuableSpawnerVisualization.java
@@ -1,0 +1,54 @@
+package net.alphalightning.bedwars.feedback.visual.impl;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.feedback.visual.Visualization;
+import net.alphalightning.bedwars.game.SpawnerType;
+import net.alphalightning.bedwars.utils.LocationUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ValuableSpawnerVisualization implements Visualization<Location> {
+
+    private final Set<Item> spawnedItems = new HashSet<>();
+    private final BedWarsPlugin plugin;
+    private final SpawnerType type;
+
+    public ValuableSpawnerVisualization(BedWarsPlugin plugin, SpawnerType type) {
+        this.plugin = plugin;
+        this.type = type;
+    }
+
+    @Override
+    public void show(@NotNull Location location) {
+        final Location spawnLocation = location.clone().add(0, 0.1D, 0);
+        final World world = location.getWorld();
+
+        visualize(world, spawnLocation);
+    }
+
+    private void visualize(World world, Location spawnLocation) {
+        final Item item = spawnItem(world, spawnLocation);
+        Bukkit.getScheduler().runTaskLater(this.plugin, () -> {
+            item.remove();
+            this.spawnedItems.remove(item);
+        }, 40L);
+    }
+
+    private @NotNull Item spawnItem(@NotNull World world, Location spawnLocation) {
+        final Location centered = LocationUtil.adjustedCentered(spawnLocation);
+        return world.spawn(centered, Item.class, false, item -> {
+            item.setItemStack(new ItemStack(this.type == SpawnerType.EMERALD ? Material.EMERALD : Material.DIAMOND));
+            item.setCanMobPickup(false);
+            item.setCanPlayerPickup(false);
+            this.spawnedItems.add(item);
+        });
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/DiamondSpawnerConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/DiamondSpawnerConfigurationStage.java
@@ -2,6 +2,9 @@ package net.alphalightning.bedwars.setup.map.stages.gamemap;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.feedback.Feedback;
+import net.alphalightning.bedwars.feedback.visual.impl.ValuableSpawnerRenderer;
+import net.alphalightning.bedwars.feedback.visual.impl.ValuableSpawnerVisualization;
+import net.alphalightning.bedwars.game.SpawnerType;
 import net.alphalightning.bedwars.setup.map.GameMapSetup;
 import net.alphalightning.bedwars.setup.map.MapSetup;
 import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
@@ -77,7 +80,11 @@ public class DiamondSpawnerConfigurationStage extends Stage implements LocationC
 
         // Diamond spawner configuration is not completed
 
-        locations.add(location.add(OFFSET));
+        final Location withOffset = location.add(OFFSET);
+        locations.add(withOffset);
+
+        new ValuableSpawnerRenderer(plugin, withOffset).render(new ValuableSpawnerVisualization(plugin, SpawnerType.DIAMOND));
+
         player.sendMessage(Component.translatable("mapsetup.stage.8.id.success", Component.text(phase)));
         Feedback.success(player);
 

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/DiamondSpawnerConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/DiamondSpawnerConfigurationStage.java
@@ -2,6 +2,8 @@ package net.alphalightning.bedwars.setup.map.stages.gamemap;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.feedback.Feedback;
+import net.alphalightning.bedwars.feedback.visual.impl.BlockEdgeRenderer;
+import net.alphalightning.bedwars.feedback.visual.impl.BlockEdgeVisualization;
 import net.alphalightning.bedwars.feedback.visual.impl.ValuableSpawnerRenderer;
 import net.alphalightning.bedwars.feedback.visual.impl.ValuableSpawnerVisualization;
 import net.alphalightning.bedwars.game.SpawnerType;
@@ -84,6 +86,7 @@ public class DiamondSpawnerConfigurationStage extends Stage implements LocationC
         locations.add(withOffset);
 
         new ValuableSpawnerRenderer(plugin, withOffset).render(new ValuableSpawnerVisualization(plugin, SpawnerType.DIAMOND));
+        new BlockEdgeRenderer(plugin, withOffset.getBlock()).render(new BlockEdgeVisualization(0x5ef2ff));
 
         player.sendMessage(Component.translatable("mapsetup.stage.8.id.success", Component.text(phase)));
         Feedback.success(player);

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/EmeraldSpawnerConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/EmeraldSpawnerConfigurationStage.java
@@ -2,6 +2,9 @@ package net.alphalightning.bedwars.setup.map.stages.gamemap;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.feedback.Feedback;
+import net.alphalightning.bedwars.feedback.visual.impl.ValuableSpawnerRenderer;
+import net.alphalightning.bedwars.feedback.visual.impl.ValuableSpawnerVisualization;
+import net.alphalightning.bedwars.game.SpawnerType;
 import net.alphalightning.bedwars.setup.map.GameMapSetup;
 import net.alphalightning.bedwars.setup.map.MapSetup;
 import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
@@ -77,7 +80,11 @@ public class EmeraldSpawnerConfigurationStage extends Stage implements LocationC
 
         // Emerald spawner configuration is not completed
 
-        locations.add(location.add(OFFSET));
+        final Location withOffset = location.add(OFFSET);
+        locations.add(withOffset);
+
+        new ValuableSpawnerRenderer(plugin, withOffset).render(new ValuableSpawnerVisualization(plugin, SpawnerType.EMERALD));
+
         player.sendMessage(Component.translatable("mapsetup.stage.7.id.success", Component.text(phase)));
         Feedback.success(player);
 

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/EmeraldSpawnerConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/EmeraldSpawnerConfigurationStage.java
@@ -2,6 +2,8 @@ package net.alphalightning.bedwars.setup.map.stages.gamemap;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.feedback.Feedback;
+import net.alphalightning.bedwars.feedback.visual.impl.BlockEdgeRenderer;
+import net.alphalightning.bedwars.feedback.visual.impl.BlockEdgeVisualization;
 import net.alphalightning.bedwars.feedback.visual.impl.ValuableSpawnerRenderer;
 import net.alphalightning.bedwars.feedback.visual.impl.ValuableSpawnerVisualization;
 import net.alphalightning.bedwars.game.SpawnerType;
@@ -84,6 +86,7 @@ public class EmeraldSpawnerConfigurationStage extends Stage implements LocationC
         locations.add(withOffset);
 
         new ValuableSpawnerRenderer(plugin, withOffset).render(new ValuableSpawnerVisualization(plugin, SpawnerType.EMERALD));
+        new BlockEdgeRenderer(plugin, withOffset.getBlock()).render(new BlockEdgeVisualization(0x21de3a));
 
         player.sendMessage(Component.translatable("mapsetup.stage.7.id.success", Component.text(phase)));
         Feedback.success(player);

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamLootspawnerConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamLootspawnerConfigurationStage.java
@@ -144,7 +144,7 @@ public class TeamLootspawnerConfigurationStage extends Stage implements TeamConf
         } else {
             new BoundingBoxRenderer(plugin, withOffset.toCenterLocation()).render(new BoundingBoxVisualization(color));
         }
-        new SpawnerRenderer(plugin, withOffset).render(new SpawnerVisualization(plugin, gameMapSetup));
+        new TeamLootSpawnerRenderer(plugin, withOffset).render(new TeamLootspawnerVisualization(plugin, gameMapSetup));
 
         player.sendMessage(Component.translatable("mapsetup.stage.10.name.success", teamName));
         Feedback.success(player);


### PR DESCRIPTION
# Description

Diese PR fügt das Rendering von fake Spawnern von Emeralds/Diamonds hinzu.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes