### PR TITLE
Load random map on startup

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
+++ b/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
@@ -67,8 +67,10 @@ public class BedWarsPlugin extends JavaPlugin {
         registerCommands();
         registerGuiIngredients();
 
-        gameStateContext = new GameStateContext(this);
-        gameStateContext.setGameState(GameState.LOBBY);
+        if (environment != Environment.DEVELOPMENT) {
+            gameStateContext = new GameStateContext(this);
+            gameStateContext.setGameState(GameState.LOBBY);
+        }
 
         getLogger().info("BedWars has been enabled");
     }

--- a/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
+++ b/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
@@ -66,11 +66,7 @@ public class BedWarsPlugin extends JavaPlugin {
         registerEvents();
         registerCommands();
         registerGuiIngredients();
-
-        if (environment != Environment.DEVELOPMENT) {
-            gameStateContext = new GameStateContext(this);
-            gameStateContext.setGameState(GameState.LOBBY);
-        }
+        registerGameMechanics();
 
         getLogger().info("BedWars has been enabled");
     }
@@ -137,6 +133,15 @@ public class BedWarsPlugin extends JavaPlugin {
                     new PaperCommandSource(sender, commandSourceStack);
 
         }, PaperCommandSource::commandSourceStack);
+    }
+
+    private void registerGameMechanics() {
+        if (environment == Environment.DEVELOPMENT) {
+            getComponentLogger().info(MiniMessage.miniMessage().deserialize("<red>Disabled <reset>game mechanics!"));
+            return;
+        }
+        gameStateContext = new GameStateContext(this);
+        gameStateContext.setGameState(GameState.LOBBY);
     }
 
     public ObjectMapper jsonMapper() {

--- a/src/main/java/net/alphalightning/bedwars/config/Configuration.java
+++ b/src/main/java/net/alphalightning/bedwars/config/Configuration.java
@@ -31,6 +31,7 @@ public class Configuration extends JacksonConfig<Default> {
         }
 
         main().environment(Environment.DEVELOPMENT);
+        main().matchmaking("8x1");
         main().minPlayers(0.8);
         save();
     }

--- a/src/main/java/net/alphalightning/bedwars/config/Default.java
+++ b/src/main/java/net/alphalightning/bedwars/config/Default.java
@@ -3,6 +3,7 @@ package net.alphalightning.bedwars.config;
 public class Default {
 
     private Environment environment;
+    private String matchmaking;
     private double minPlayers;
 
     public Environment environment() {
@@ -13,11 +14,19 @@ public class Default {
         return minPlayers;
     }
 
+    public String matchmaking() {
+        return matchmaking;
+    }
+
     public void environment(Environment environment) {
         this.environment = environment;
     }
 
     public void minPlayers(double minPlayers) {
         this.minPlayers = minPlayers;
+    }
+
+    public void matchmaking(String matchmaking) {
+        this.matchmaking = matchmaking;
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
@@ -24,7 +24,7 @@ public class MapLoader {
         File directory = this.plugin.getDataFolder().toPath().resolve("maps").toFile();
         File[] files = directory.listFiles((_, name) -> {
             String[] parts = name.split("\\.");
-            return parts[1].equalsIgnoreCase("json") && !name.equalsIgnoreCase("lobby"); // Find only json files
+            return parts[1].equalsIgnoreCase("json") && !parts[0].equalsIgnoreCase("lobby"); // Find only json files and ignore the lobby
         });
 
         if (files == null) {

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
@@ -1,0 +1,49 @@
+package net.alphalightning.bedwars.game.map;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.setup.map.jackson.GameMap;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public class MapLoader {
+
+    private final BedWarsPlugin plugin;
+    private final String matchmaking;
+
+    public MapLoader(BedWarsPlugin plugin, String matchmaking) {
+        this.plugin = plugin;
+        this.matchmaking = matchmaking;
+    }
+
+    public Collection<GameMap> loadAll() {
+        File directory = this.plugin.getDataFolder().toPath().resolve("maps").toFile();
+        File[] files = directory.listFiles((_, name) -> {
+            String[] parts = name.split("\\.");
+            return parts[1].equalsIgnoreCase("json"); // Find only json files
+        });
+
+        if (files == null) {
+            return Collections.emptyList();
+        }
+
+        Collection<GameMap> maps = new ArrayList<>();
+        File tmpFile = null;
+        try {
+            for (File file : files) {
+                tmpFile = file;
+                GameMap gameMap = this.plugin.jsonMapper().readValue(file, GameMap.class);
+                maps.add(gameMap);
+            }
+            return maps;
+
+        } catch (IOException exception) {
+            this.plugin.getLogger().severe("Could not read file " + tmpFile.getName() + ": " + exception.getMessage());
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
@@ -7,8 +7,8 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 public class MapLoader {
 
@@ -20,7 +20,7 @@ public class MapLoader {
         this.matchmaking = matchmaking;
     }
 
-    public Collection<GameMap> loadAll() {
+    public List<GameMap> loadAll() {
         File directory = this.plugin.getDataFolder().toPath().resolve("maps").toFile();
         File[] files = directory.listFiles((_, name) -> {
             String[] parts = name.split("\\.");
@@ -31,7 +31,7 @@ public class MapLoader {
             return Collections.emptyList();
         }
 
-        Collection<GameMap> maps = new ArrayList<>();
+        List<GameMap> maps = new ArrayList<>();
         File tmpFile = null;
         try {
             for (File file : files) {

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
@@ -2,6 +2,7 @@ package net.alphalightning.bedwars.game.map;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.setup.map.jackson.GameMap;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +37,10 @@ public class MapLoader {
             for (File file : files) {
                 tmpFile = file;
                 GameMap gameMap = this.plugin.jsonMapper().readValue(file, GameMap.class);
-                maps.add(gameMap);
+
+                if (isValidMatchmaking(gameMap)) {
+                    maps.add(gameMap);
+                }
             }
             return maps;
 
@@ -45,5 +49,11 @@ public class MapLoader {
         }
 
         return Collections.emptyList();
+    }
+
+    private boolean isValidMatchmaking(@NotNull GameMap gameMap) {
+        int teamSize = gameMap.teamSize();
+        int teams = gameMap.teams().size();
+        return matchmaking.equalsIgnoreCase(teams + "x" + teamSize);
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapLoader.java
@@ -24,7 +24,7 @@ public class MapLoader {
         File directory = this.plugin.getDataFolder().toPath().resolve("maps").toFile();
         File[] files = directory.listFiles((_, name) -> {
             String[] parts = name.split("\\.");
-            return parts[1].equalsIgnoreCase("json"); // Find only json files
+            return parts[1].equalsIgnoreCase("json") && !name.equalsIgnoreCase("lobby"); // Find only json files
         });
 
         if (files == null) {

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
@@ -6,17 +6,23 @@ import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
+import java.util.List;
+import java.util.Random;
 
 public class MapManager {
 
-    private final Collection<GameMap> maps;
+    private final List<GameMap> maps;
 
     public MapManager(@NotNull BedWarsPlugin plugin) {
         String matchmaking = plugin.configuration().main().matchmaking();
 
         this.maps = new MapLoader(plugin, matchmaking).loadAll();
         printMatchmakingInfo(plugin, matchmaking);
+    }
+
+    public @NotNull GameMap selectRandom() {
+        int index = new Random().nextInt(this.maps.size());
+        return this.maps.get(index);
     }
 
     private void printMatchmakingInfo(BedWarsPlugin plugin, String matchmaking) {

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
@@ -1,0 +1,34 @@
+package net.alphalightning.bedwars.game.map;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.setup.map.jackson.GameMap;
+import net.alphalightning.bedwars.translation.NamedTranslationArgument;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public class MapManager {
+
+    private final Collection<GameMap> maps;
+
+    public MapManager(@NotNull BedWarsPlugin plugin) {
+        String matchmaking = plugin.configuration().main().matchmaking();
+
+        this.maps = new MapLoader(plugin, matchmaking).loadAll();
+        printMatchmakingInfo(plugin, matchmaking);
+    }
+
+    private void printMatchmakingInfo(BedWarsPlugin plugin, String matchmaking) {
+        if (this.maps.isEmpty()) {
+            plugin.getComponentLogger().warn(Component.translatable("state.lobby.matchmaking.error",
+                    NamedTranslationArgument.component("matchmaking", Component.text(matchmaking)))
+            );
+            return;
+        }
+        plugin.getComponentLogger().info(Component.translatable("state.lobby.matchmaking",
+                NamedTranslationArgument.numeric("size", this.maps.size()),
+                NamedTranslationArgument.component("matchmaking", Component.text(matchmaking)))
+        );
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -29,14 +29,13 @@ public class LobbyState extends AbstractGameState implements Listener {
     private final GameStateContext context;
     private final Configuration configuration;
     private final LobbyCountdown countdown;
-    private final MapManager mapManager;
 
     public LobbyState(@NotNull BedWarsPlugin plugin, GameStateContext context) {
         super(context);
         this.context = context;
         this.configuration = plugin.configuration();
         this.countdown = new LobbyCountdown(plugin, context, 30);
-        this.mapManager = new MapManager(plugin);
+        new MapManager(plugin);
 
         context.requiredPlayers(calculateMinPlayers());
         countdown.start();

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -25,8 +25,6 @@ import org.jetbrains.annotations.NotNull;
 
 public class LobbyState extends AbstractGameState implements Listener {
 
-    private static final int MAX_PLAYERS = 4; //TODO: Make this dynamic based on selected map
-
     private final GameStateContext context;
     private final Configuration configuration;
     private final LobbyCountdown countdown;
@@ -41,6 +39,8 @@ public class LobbyState extends AbstractGameState implements Listener {
         this.mapManager = new MapManager(plugin);
 
         this.gameMap = mapManager.selectRandom();
+        Bukkit.getServer().setMaxPlayers(gameMap.teams().size() * gameMap.teamSize());
+
         plugin.getComponentLogger().info(Component.translatable("state.lobby.map",
                 NamedTranslationArgument.component("map", Component.text(gameMap.name())))
         );
@@ -74,7 +74,7 @@ public class LobbyState extends AbstractGameState implements Listener {
         event.joinMessage(Component.translatable("state.lobby.join",
                 NamedTranslationArgument.component("name", player.displayName()),
                 NamedTranslationArgument.numeric("current", Bukkit.getOnlinePlayers().size()),
-                NamedTranslationArgument.numeric("max", MAX_PLAYERS)
+                NamedTranslationArgument.numeric("max", Bukkit.getMaxPlayers())
         ));
         preparePlayer(player);
         teleportPlayer(player);
@@ -128,7 +128,7 @@ public class LobbyState extends AbstractGameState implements Listener {
 
     private int calculateMinPlayers() {
         double factor = this.configuration.main().minPlayers();
-        double calculated = MAX_PLAYERS * factor;
+        double calculated = Bukkit.getMaxPlayers() * factor;
 
         return (int) Math.floor(calculated);
     }

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -3,6 +3,7 @@ package net.alphalightning.bedwars.game.state.states;
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.config.Configuration;
 import net.alphalightning.bedwars.game.countdown.LobbyCountdown;
+import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
 import net.alphalightning.bedwars.game.state.GameStateContext;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
@@ -28,12 +29,14 @@ public class LobbyState extends AbstractGameState implements Listener {
     private final GameStateContext context;
     private final Configuration configuration;
     private final LobbyCountdown countdown;
+    private final MapManager mapManager;
 
     public LobbyState(@NotNull BedWarsPlugin plugin, GameStateContext context) {
         super(context);
         this.context = context;
         this.configuration = plugin.configuration();
         this.countdown = new LobbyCountdown(plugin, context, 30);
+        this.mapManager = new MapManager(plugin);
 
         context.requiredPlayers(calculateMinPlayers());
         countdown.start();
@@ -51,6 +54,8 @@ public class LobbyState extends AbstractGameState implements Listener {
         this.countdown.cancel();
         context.logger().info(Component.translatable("state.lobby.stop"));
     }
+
+    // --------------------- State related event logics ---------------------
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
@@ -111,6 +116,8 @@ public class LobbyState extends AbstractGameState implements Listener {
             PlayerUtil.updateCountdownInformation(player, this.countdown.duration(), this.countdown.remainingTime());
         }
     }
+
+    // --------------------- Private shit ---------------------
 
     private int calculateMinPlayers() {
         double factor = this.configuration.main().minPlayers();

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -29,7 +29,7 @@ public class LobbyState extends AbstractGameState implements Listener {
     private final Configuration configuration;
     private final LobbyCountdown countdown;
     private final MapManager mapManager;
-    private final GameMap gameMap;
+    private GameMap gameMap;
 
     public LobbyState(@NotNull BedWarsPlugin plugin, GameStateContext context) {
         super(context);
@@ -38,15 +38,8 @@ public class LobbyState extends AbstractGameState implements Listener {
         this.countdown = new LobbyCountdown(plugin, context, 30);
         this.mapManager = new MapManager(plugin);
 
-        this.gameMap = mapManager.selectRandom();
-        Bukkit.getServer().setMaxPlayers(gameMap.teams().size() * gameMap.teamSize());
-
-        plugin.getComponentLogger().info(Component.translatable("state.lobby.map",
-                NamedTranslationArgument.component("map", Component.text(gameMap.name())))
-        );
-
-        context.requiredPlayers(calculateMinPlayers());
-        countdown.start();
+        selectMap(plugin);
+        startCountdown();
 
         Bukkit.getPluginManager().registerEvents(this, plugin);
     }
@@ -138,6 +131,24 @@ public class LobbyState extends AbstractGameState implements Listener {
         if (location != null) {
             player.teleport(location);
         }
+    }
+
+    private void startCountdown() {
+        this.context.requiredPlayers(calculateMinPlayers());
+        this.countdown.start();
+    }
+
+    private void selectMap(@NotNull BedWarsPlugin plugin) {
+        this.gameMap = mapManager.selectRandom();
+        updateServerInfo();
+
+        plugin.getComponentLogger().info(Component.translatable("state.lobby.map",
+                NamedTranslationArgument.component("map", Component.text(gameMap.name()))));
+    }
+
+    private void updateServerInfo() {
+        Bukkit.getServer().motd(Component.text(this.gameMap.name()));
+        Bukkit.getServer().setMaxPlayers(this.gameMap.teams().size() * this.gameMap.teamSize());
     }
 }
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -6,6 +6,7 @@ import net.alphalightning.bedwars.game.countdown.LobbyCountdown;
 import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
 import net.alphalightning.bedwars.game.state.GameStateContext;
+import net.alphalightning.bedwars.setup.map.jackson.GameMap;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.alphalightning.bedwars.util.PlayerUtil;
 import net.kyori.adventure.text.Component;
@@ -29,13 +30,20 @@ public class LobbyState extends AbstractGameState implements Listener {
     private final GameStateContext context;
     private final Configuration configuration;
     private final LobbyCountdown countdown;
+    private final MapManager mapManager;
+    private final GameMap gameMap;
 
     public LobbyState(@NotNull BedWarsPlugin plugin, GameStateContext context) {
         super(context);
         this.context = context;
         this.configuration = plugin.configuration();
         this.countdown = new LobbyCountdown(plugin, context, 30);
-        new MapManager(plugin);
+        this.mapManager = new MapManager(plugin);
+
+        this.gameMap = mapManager.selectRandom();
+        plugin.getComponentLogger().info(Component.translatable("state.lobby.map",
+                NamedTranslationArgument.component("map", Component.text(gameMap.name())))
+        );
 
         context.requiredPlayers(calculateMinPlayers());
         countdown.start();

--- a/src/main/java/net/alphalightning/bedwars/setup/map/jackson/GameMap.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/jackson/GameMap.java
@@ -1,26 +1,27 @@
 package net.alphalightning.bedwars.setup.map.jackson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import net.alphalightning.bedwars.game.SpawnerType;
 
 import java.util.HashMap;
 import java.util.List;
 
-public class GameMap {
-
-    private final String name;
-    private final int teamSize;
-    private final int minBuildHeight;
-    private final int maxBuildHeight;
-    private final boolean slowIron;
-    private final JacksonLocation spectatorSpawn;
-    private final List<Team> teams;
-    private final List<SimpleJacksonLocation> shopVillager;
-    private final List<SimpleJacksonLocation> upgradeVillager;
-    private final HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner;
+public record GameMap(String name, int teamSize, int minBuildHeight, int maxBuildHeight, boolean slowIron, JacksonLocation spectatorSpawn, List<Team> teams, List<SimpleJacksonLocation> shopVillager, List<SimpleJacksonLocation> upgradeVillager, HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner) {
 
     @JsonCreator
-    public GameMap(String name, int teamSize, int minBuildHeight, int maxBuildHeight, boolean slowIron, JacksonLocation spectatorSpawn, List<Team> teams, List<SimpleJacksonLocation> shopVillager, List<SimpleJacksonLocation> upgradeVillager, HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner) {
+    public GameMap(
+            @JsonProperty("name") String name,
+            @JsonProperty("teamSize") int teamSize,
+            @JsonProperty("minBuildHeight") int minBuildHeight,
+            @JsonProperty("maxBuildHeight") int maxBuildHeight,
+            @JsonProperty("slowIron") boolean slowIron,
+            @JsonProperty("spectatorSpawn") JacksonLocation spectatorSpawn,
+            @JsonProperty("teams") List<Team> teams,
+            @JsonProperty("shopVillager") List<SimpleJacksonLocation> shopVillager,
+            @JsonProperty("upgradeVillager") List<SimpleJacksonLocation> upgradeVillager,
+            @JsonProperty("spawner") HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner) {
+
         this.name = name;
         this.teamSize = teamSize;
         this.minBuildHeight = minBuildHeight;
@@ -31,45 +32,5 @@ public class GameMap {
         this.shopVillager = shopVillager;
         this.upgradeVillager = upgradeVillager;
         this.spawner = spawner;
-    }
-
-    public String name() {
-        return name;
-    }
-
-    public int teamSize() {
-        return teamSize;
-    }
-
-    public int minBuildHeight() {
-        return minBuildHeight;
-    }
-
-    public int maxBuildHeight() {
-        return maxBuildHeight;
-    }
-
-    public boolean slowIron() {
-        return slowIron;
-    }
-
-    public JacksonLocation spectatorSpawn() {
-        return spectatorSpawn;
-    }
-
-    public List<Team> teams() {
-        return teams;
-    }
-
-    public List<SimpleJacksonLocation> shopVillager() {
-        return shopVillager;
-    }
-
-    public List<SimpleJacksonLocation> upgradeVillager() {
-        return upgradeVillager;
-    }
-
-    public HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner() {
-        return spawner;
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/map/jackson/Team.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/jackson/Team.java
@@ -2,6 +2,7 @@ package net.alphalightning.bedwars.setup.map.jackson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bukkit.Location;
 
 public class Team {
@@ -16,12 +17,20 @@ public class Team {
     private SimpleJacksonLocation lootspawner;
 
     @JsonCreator
-    public Team(String name, int color) {
+    public Team(@JsonProperty("name") String name, int color) {
         this(name, color, null, null, null, null, null);
     }
 
     @JsonCreator
-    public Team(String name, int color,  JacksonLocation spawnpoint, SimpleJacksonLocation chest, SimpleJacksonLocation bedBottomHalf, SimpleJacksonLocation bedTopHalf, SimpleJacksonLocation lootspawner) {
+    public Team(
+            @JsonProperty("name") String name,
+            int color,
+            @JsonProperty("spawnpoint") JacksonLocation spawnpoint,
+            @JsonProperty("chest") SimpleJacksonLocation chest,
+            @JsonProperty("bedBottomHalf") SimpleJacksonLocation bedBottomHalf,
+            @JsonProperty("bedTopHalf") SimpleJacksonLocation bedTopHalf,
+            @JsonProperty("lootspawner") SimpleJacksonLocation lootspawner) {
+
         this.color = color;
         this.name = name;
         this.spawnpoint = spawnpoint;

--- a/src/main/java/net/alphalightning/bedwars/setup/map/jackson/Team.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/jackson/Team.java
@@ -16,21 +16,23 @@ public class Team {
     private SimpleJacksonLocation bedTopHalf;
     private SimpleJacksonLocation lootspawner;
 
+
     @JsonCreator
-    public Team(@JsonProperty("name") String name, int color) {
+    public Team(@JsonProperty("name") String name,
+                @JsonProperty("spawnpoint") JacksonLocation spawnpoint,
+                @JsonProperty("chest") SimpleJacksonLocation chest,
+                @JsonProperty("bedBottomHalf") SimpleJacksonLocation bedBottomHalf,
+                @JsonProperty("bedTopHalf") SimpleJacksonLocation bedTopHalf,
+                @JsonProperty("lootspawner") SimpleJacksonLocation lootspawner) {
+
+        this(name, -1, spawnpoint, chest, bedBottomHalf, bedTopHalf, lootspawner);
+    }
+
+    public Team(String name, int color) {
         this(name, color, null, null, null, null, null);
     }
 
-    @JsonCreator
-    public Team(
-            @JsonProperty("name") String name,
-            int color,
-            @JsonProperty("spawnpoint") JacksonLocation spawnpoint,
-            @JsonProperty("chest") SimpleJacksonLocation chest,
-            @JsonProperty("bedBottomHalf") SimpleJacksonLocation bedBottomHalf,
-            @JsonProperty("bedTopHalf") SimpleJacksonLocation bedTopHalf,
-            @JsonProperty("lootspawner") SimpleJacksonLocation lootspawner) {
-
+    public Team(String name, int color, JacksonLocation spawnpoint, SimpleJacksonLocation chest, SimpleJacksonLocation bedBottomHalf, SimpleJacksonLocation bedTopHalf, SimpleJacksonLocation lootspawner) {
         this.color = color;
         this.name = name;
         this.spawnpoint = spawnpoint;

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -40,7 +40,7 @@ state.lobby.abort = <red>Start abgebrochen. Warten auf weitere Spieler...
 state.lobby.idle = <red>Warten auf weitere Spieler...
 state.lobby.join = <name> <gray>hat das Spiel betreten (<current>/<max>).
 state.lobby.spawn = <gold>WARNUNG: Der Lobbyspawn konnte nicht geladen werden!
-state.lobby.matchmaking = Es wurden <gold><size> Maps <reset>für das Matchmaking <purple><matchmaking> <reset>gefunden.
+state.lobby.matchmaking = Es wurden <gold><size> Maps <reset>für das Matchmaking <light_purple><matchmaking> <reset>gefunden.
 state.lobby.matchmaking.error = <gold>WARNUNG: Es konnte keine GameMap mit der konfigurierten Matchmaking Größe (<matchmaking>) geladen werden!
 
 state.ingame.start = <yellow>Das Spiel beginnt!

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -40,6 +40,8 @@ state.lobby.abort = <red>Start abgebrochen. Warten auf weitere Spieler...
 state.lobby.idle = <red>Warten auf weitere Spieler...
 state.lobby.join = <name> <gray>hat das Spiel betreten (<current>/<max>).
 state.lobby.spawn = <gold>WARNUNG: Der Lobbyspawn konnte nicht geladen werden!
+state.lobby.matchmaking = Es wurden <gold><size> Maps <reset>für das Matchmaking <purple><matchmaking> <reset>gefunden.
+state.lobby.matchmaking.error = <gold>WARNUNG: Es konnte keine GameMap mit der konfigurierten Matchmaking (<matchmaking>) Größe geladen werden!
 
 state.ingame.start = <yellow>Das Spiel beginnt!
 state.ingame.stop = Die normale Kampfphase ist beendet.

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -42,6 +42,7 @@ state.lobby.join = <name> <gray>hat das Spiel betreten (<current>/<max>).
 state.lobby.spawn = <gold>WARNUNG: Der Lobbyspawn konnte nicht geladen werden!
 state.lobby.matchmaking = Es wurden <gold><size> Maps <reset>für das Matchmaking <light_purple><matchmaking> <reset>gefunden.
 state.lobby.matchmaking.error = <gold>WARNUNG: Es konnte keine GameMap mit der konfigurierten Matchmaking Größe (<matchmaking>) geladen werden!
+state.lobby.map = Es wurde zufällig die Map <yellow><map> <reset>zum Spielen ausgewählt.
 
 state.ingame.start = <yellow>Das Spiel beginnt!
 state.ingame.stop = Die normale Kampfphase ist beendet.

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -41,7 +41,7 @@ state.lobby.idle = <red>Warten auf weitere Spieler...
 state.lobby.join = <name> <gray>hat das Spiel betreten (<current>/<max>).
 state.lobby.spawn = <gold>WARNUNG: Der Lobbyspawn konnte nicht geladen werden!
 state.lobby.matchmaking = Es wurden <gold><size> Maps <reset>für das Matchmaking <purple><matchmaking> <reset>gefunden.
-state.lobby.matchmaking.error = <gold>WARNUNG: Es konnte keine GameMap mit der konfigurierten Matchmaking (<matchmaking>) Größe geladen werden!
+state.lobby.matchmaking.error = <gold>WARNUNG: Es konnte keine GameMap mit der konfigurierten Matchmaking Größe (<matchmaking>) geladen werden!
 
 state.ingame.start = <yellow>Das Spiel beginnt!
 state.ingame.stop = Die normale Kampfphase ist beendet.


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Läd eine zufällige Map beim Serverstart. Es werden nur Maps mit dem entsprechend konfiguriertem Matchmaking berücksichtigt - nicht jedoch die Lobby oder andere Dateien in dem Ordner, welche nicht eine JSON-Datei sind.
Zusätzlich wird die maximale Spielerzahl auf dem Server dynamisch gesetzt und die statische temporäre Mathematik für den Start des Countdowns entfernt.
Der Grundstein für Forcemapping wurde bereits mit der Implementierung gesetzt. Zusätzlich werden die Spielmechaniken in der Development-Umgebung deaktiviert.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes