### PR TITLE
Implement forcemapping

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
+++ b/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
@@ -65,10 +65,10 @@ public class BedWarsPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        registerGameMechanics();
         registerEvents();
         registerCommands();
         registerGuiIngredients();
-        registerGameMechanics();
 
         getLogger().info("BedWars has been enabled");
     }
@@ -95,6 +95,17 @@ public class BedWarsPlugin extends JavaPlugin {
 
         environment = configuration.main().environment();
         getComponentLogger().info(MiniMessage.miniMessage().deserialize("Using the environment " + Environment.colored(environment)));
+    }
+
+    private void registerGameMechanics() {
+        if (environment == Environment.DEVELOPMENT) {
+            getComponentLogger().info(MiniMessage.miniMessage().deserialize("<red>Disabled <reset>game mechanics!"));
+            return;
+        }
+        WorldUtil.prepareWorlds(Bukkit.getWorlds());
+
+        gameStateContext = new GameStateContext(this);
+        gameStateContext.setGameState(GameState.LOBBY);
     }
 
     private void registerEvents() {
@@ -141,17 +152,6 @@ public class BedWarsPlugin extends JavaPlugin {
     private void registerGuiIngredients() {
         Structure.addGlobalIngredient('.', new BackgroundGuiItem(false));
         Structure.addGlobalIngredient('#', new BackgroundGuiItem(true));
-    }
-
-    private void registerGameMechanics() {
-        if (environment == Environment.DEVELOPMENT) {
-            getComponentLogger().info(MiniMessage.miniMessage().deserialize("<red>Disabled <reset>game mechanics!"));
-            return;
-        }
-        WorldUtil.prepareWorlds(Bukkit.getWorlds());
-
-        gameStateContext = new GameStateContext(this);
-        gameStateContext.setGameState(GameState.LOBBY);
     }
 
     // --------------------- Exposure---------------------

--- a/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
+++ b/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import de.eldoria.jacksonbukkit.JacksonPaper;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.alphalightning.bedwars.commands.CreateMapCommand;
+import net.alphalightning.bedwars.commands.ForceMapCommand;
 import net.alphalightning.bedwars.commands.TestGuiCommand;
 import net.alphalightning.bedwars.commands.cloud.sender.PaperCommandSource;
 import net.alphalightning.bedwars.commands.cloud.sender.PaperPlayerCommandSource;
@@ -119,6 +120,9 @@ public class BedWarsPlugin extends JavaPlugin {
             getComponentLogger().info(MiniMessage.miniMessage().deserialize("<green>Enabled <reset>map creation"));
             return;
         }
+
+        new ForceMapCommand(this).register(manager);
+
         getComponentLogger().info(MiniMessage.miniMessage().deserialize("<red>Disabled <reset>map creation"));
     }
 

--- a/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
+++ b/src/main/java/net/alphalightning/bedwars/BedWarsPlugin.java
@@ -113,6 +113,9 @@ public class BedWarsPlugin extends JavaPlugin {
                 .captionFormatter(ComponentCaptionFormatter.miniMessage())
                 .registerTo(manager);
 
+        if (environment != Environment.DEVELOPMENT) {
+            new ForceMapCommand(this).register(manager);
+        }
         if (environment != Environment.PRODUCTION) {
             new TestGuiCommand(this).register(manager);
             new CreateMapCommand(this, setupManager).register(manager);
@@ -120,8 +123,6 @@ public class BedWarsPlugin extends JavaPlugin {
             getComponentLogger().info(MiniMessage.miniMessage().deserialize("<green>Enabled <reset>map creation"));
             return;
         }
-
-        new ForceMapCommand(this).register(manager);
 
         getComponentLogger().info(MiniMessage.miniMessage().deserialize("<red>Disabled <reset>map creation"));
     }

--- a/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
+++ b/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
@@ -8,7 +8,6 @@ import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.states.LobbyState;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.translation.GlobalTranslator;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.context.CommandContext;
@@ -66,20 +65,18 @@ public class ForceMapCommand extends PaperCommand<@NotNull BedWarsPlugin> {
             return;
         }
 
-        forceMap(lobbyState.mapManager(), player, name);
-        updateScoreboards(lobbyState);
+        forceMap(lobbyState, player, name);
     }
 
-    private void forceMap(@NotNull MapManager manager, @NotNull Player player, String name) {
+    private void forceMap(@NotNull LobbyState lobbyState, @NotNull Player player, String name) {
+        MapManager manager = lobbyState.mapManager();
+
         if (!(this.isForced = manager.select(name))) {
             return;
         }
-        player.sendMessage(Component.translatable("command.forcemap.success", NamedTranslationArgument.component("name", Component.text(name))));
-    }
 
-    private void updateScoreboards(@NotNull LobbyState lobbyState) {
-        lobbyState.scoreboards().forEach((player, scoreboard) -> scoreboard.updateLine(1, GlobalTranslator.render(Component.translatable("state.lobby.scoreboard.map",
-                NamedTranslationArgument.component("name", Component.text(lobbyState.mapManager().selected().name()))
-        ), player.locale())));
+        lobbyState.updateMapName(lobbyState);
+        lobbyState.updateSelectedMap(manager.selected());
+        player.sendMessage(Component.translatable("command.forcemap.success", NamedTranslationArgument.component("name", Component.text(name))));
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
+++ b/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
@@ -4,6 +4,7 @@ import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.commands.cloud.sender.PaperCommand;
 import net.alphalightning.bedwars.commands.cloud.sender.PaperCommandSource;
 import net.alphalightning.bedwars.commands.cloud.sender.PaperPlayerCommandSource;
+import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.states.LobbyState;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
@@ -57,12 +58,19 @@ public class ForceMapCommand extends PaperCommand<@NotNull BedWarsPlugin> {
             return;
         }
 
-        this.isForced = true;
         String name = context.get("name");
-        lobbyState.mapManager().select(name);
 
-        player.sendMessage(Component.translatable("command.forcemap.success",
-                NamedTranslationArgument.component("name", Component.text(name))
-        ));
+        if (lobbyState.mapManager().selected().name().equalsIgnoreCase(name)) {
+            player.sendMessage(Component.translatable("command.forcemap.error.same"));
+            return;
+        }
+        forceMap(lobbyState.mapManager(), player, name);
+    }
+
+    private void forceMap(@NotNull MapManager manager, @NotNull Player player, String name) {
+        if (!(this.isForced = manager.select(name))) {
+            return;
+        }
+        player.sendMessage(Component.translatable("command.forcemap.success", NamedTranslationArgument.component("name", Component.text(name))));
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
+++ b/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
@@ -8,6 +8,7 @@ import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.states.LobbyState;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.translation.GlobalTranslator;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.context.CommandContext;
@@ -64,7 +65,9 @@ public class ForceMapCommand extends PaperCommand<@NotNull BedWarsPlugin> {
             player.sendMessage(Component.translatable("command.forcemap.error.same"));
             return;
         }
+
         forceMap(lobbyState.mapManager(), player, name);
+        updateScoreboards(lobbyState);
     }
 
     private void forceMap(@NotNull MapManager manager, @NotNull Player player, String name) {
@@ -72,5 +75,11 @@ public class ForceMapCommand extends PaperCommand<@NotNull BedWarsPlugin> {
             return;
         }
         player.sendMessage(Component.translatable("command.forcemap.success", NamedTranslationArgument.component("name", Component.text(name))));
+    }
+
+    private void updateScoreboards(@NotNull LobbyState lobbyState) {
+        lobbyState.scoreboards().forEach((player, scoreboard) -> scoreboard.updateLine(1, GlobalTranslator.render(Component.translatable("state.lobby.scoreboard.map",
+                NamedTranslationArgument.component("name", Component.text(lobbyState.mapManager().selected().name()))
+        ), player.locale())));
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
+++ b/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
@@ -75,8 +75,8 @@ public class ForceMapCommand extends PaperCommand<@NotNull BedWarsPlugin> {
             return;
         }
 
-        lobbyState.updateMapName(lobbyState);
         lobbyState.updateSelectedMap(manager.selected());
+        lobbyState.updateMapName(lobbyState);
         player.sendMessage(Component.translatable("command.forcemap.success", NamedTranslationArgument.component("name", Component.text(name))));
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
+++ b/src/main/java/net/alphalightning/bedwars/commands/ForceMapCommand.java
@@ -1,0 +1,68 @@
+package net.alphalightning.bedwars.commands;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import net.alphalightning.bedwars.commands.cloud.sender.PaperCommand;
+import net.alphalightning.bedwars.commands.cloud.sender.PaperCommandSource;
+import net.alphalightning.bedwars.commands.cloud.sender.PaperPlayerCommandSource;
+import net.alphalightning.bedwars.game.state.states.LobbyState;
+import net.alphalightning.bedwars.translation.NamedTranslationArgument;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.minecraft.extras.RichDescription;
+import org.incendo.cloud.suggestion.Suggestion;
+import org.incendo.cloud.suggestion.SuggestionProvider;
+import org.jetbrains.annotations.NotNull;
+
+import static org.incendo.cloud.parser.standard.StringParser.stringParser;
+
+public class ForceMapCommand extends PaperCommand<@NotNull BedWarsPlugin> {
+
+    private boolean isForced = false;
+
+    public ForceMapCommand(BedWarsPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void register(@NotNull CommandManager<PaperCommandSource> commandManager) {
+        commandManager.command(commandManager.commandBuilder("forcemap")
+                .commandDescription(RichDescription.translatable("command.forcemap.description"))
+                .senderType(PaperPlayerCommandSource.class)
+                .permission("bedwars.command.forcemap")
+                .required("name", stringParser(), suggestions())
+                .handler(this::runCommand)
+        );
+    }
+
+    private SuggestionProvider<PaperPlayerCommandSource> suggestions() {
+        if (!(this.plugin.gameStateContext().currentState() instanceof LobbyState lobbyState)) {
+            return SuggestionProvider.noSuggestions();
+        }
+        return SuggestionProvider.suggesting(lobbyState.mapManager().maps()
+                .stream().map(map -> Suggestion.suggestion(map.name()))
+                .toList());
+    }
+
+    private void runCommand(@NotNull CommandContext<PaperPlayerCommandSource> context) {
+        Player player = (Player) context.sender().plattformSender();
+
+        if (!(this.plugin.gameStateContext().currentState() instanceof LobbyState lobbyState)) {
+            player.sendMessage(Component.translatable("command.forcemap.error.gamestate"));
+            return;
+        }
+        if (this.isForced) {
+            player.sendMessage(Component.translatable("command.forcemap.error.used"));
+            return;
+        }
+
+        this.isForced = true;
+        String name = context.get("name");
+        lobbyState.mapManager().select(name);
+
+        player.sendMessage(Component.translatable("command.forcemap.success",
+                NamedTranslationArgument.component("name", Component.text(name))
+        ));
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
@@ -32,13 +32,19 @@ public class MapManager {
         return gameMap;
     }
 
-    public void select(String name) {
+    public boolean select(String name) {
         this.selected = this.maps.stream()
                 .filter(map -> map.name().equalsIgnoreCase(name))
                 .findFirst()
                 .orElse(null);
 
         updateServerInfo();
+
+        return this.selected != null;
+    }
+
+    public GameMap selected() {
+        return selected;
     }
 
     public List<GameMap> maps() {

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
@@ -6,6 +6,7 @@ import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Random;
@@ -22,7 +23,11 @@ public class MapManager {
         printMatchmakingInfo(plugin, matchmaking);
     }
 
-    public @NotNull GameMap selectRandom() {
+    public @Nullable GameMap selectRandom() {
+        if (this.maps.isEmpty()) {
+            return null;
+        }
+
         int index = new Random().nextInt(this.maps.size());
         this.selected = this.maps.get(index);
 

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
@@ -5,6 +5,7 @@ import net.alphalightning.bedwars.setup.map.jackson.GameMap;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Random;
@@ -12,6 +13,7 @@ import java.util.Random;
 public class MapManager {
 
     private final List<GameMap> maps;
+    private GameMap selected; // The selected gamemap
 
     public MapManager(@NotNull BedWarsPlugin plugin) {
         String matchmaking = plugin.configuration().main().matchmaking();
@@ -22,7 +24,28 @@ public class MapManager {
 
     public @NotNull GameMap selectRandom() {
         int index = new Random().nextInt(this.maps.size());
-        return this.maps.get(index);
+        GameMap gameMap = this.maps.get(index);
+
+        this.selected = gameMap;
+        return gameMap;
+    }
+
+    public @Nullable GameMap select(String name) {
+        GameMap gameMap = this.maps.stream()
+                .filter(map -> map.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
+
+        this.selected = gameMap;
+        return gameMap;
+    }
+
+    public GameMap selectedMap() {
+        return selected;
+    }
+
+    public List<GameMap> maps() {
+        return this.maps;
     }
 
     private void printMatchmakingInfo(BedWarsPlugin plugin, String matchmaking) {

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
@@ -48,6 +48,8 @@ public class MapManager {
         return true;
     }
 
+    // --------------------- Exposure ---------------------
+
     public GameMap selected() {
         return selected;
     }
@@ -55,6 +57,8 @@ public class MapManager {
     public List<GameMap> maps() {
         return this.maps;
     }
+
+    // --------------------- Private shit ---------------------
 
     private void updateServerInfo() {
         Bukkit.getServer().motd(Component.text(this.selected.name()));

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
@@ -24,12 +24,10 @@ public class MapManager {
 
     public @NotNull GameMap selectRandom() {
         int index = new Random().nextInt(this.maps.size());
-        GameMap gameMap = this.maps.get(index);
+        this.selected = this.maps.get(index);
 
-        this.selected = gameMap;
         updateServerInfo();
-
-        return gameMap;
+        return this.selected;
     }
 
     public boolean select(String name) {
@@ -38,9 +36,11 @@ public class MapManager {
                 .findFirst()
                 .orElse(null);
 
+        if (this.selected == null) {
+            return false;
+        }
         updateServerInfo();
-
-        return this.selected != null;
+        return true;
     }
 
     public GameMap selected() {

--- a/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
+++ b/src/main/java/net/alphalightning/bedwars/game/map/MapManager.java
@@ -4,8 +4,8 @@ import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.setup.map.jackson.GameMap;
 import net.alphalightning.bedwars.translation.NamedTranslationArgument;
 import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Random;
@@ -27,25 +27,27 @@ public class MapManager {
         GameMap gameMap = this.maps.get(index);
 
         this.selected = gameMap;
+        updateServerInfo();
+
         return gameMap;
     }
 
-    public @Nullable GameMap select(String name) {
-        GameMap gameMap = this.maps.stream()
+    public void select(String name) {
+        this.selected = this.maps.stream()
                 .filter(map -> map.name().equalsIgnoreCase(name))
                 .findFirst()
                 .orElse(null);
 
-        this.selected = gameMap;
-        return gameMap;
-    }
-
-    public GameMap selectedMap() {
-        return selected;
+        updateServerInfo();
     }
 
     public List<GameMap> maps() {
         return this.maps;
+    }
+
+    private void updateServerInfo() {
+        Bukkit.getServer().motd(Component.text(this.selected.name()));
+        Bukkit.getServer().setMaxPlayers(this.selected.teams().size() * this.selected.teamSize());
     }
 
     private void printMatchmakingInfo(BedWarsPlugin plugin, String matchmaking) {

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -216,15 +216,9 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
 
     private void selectMap(@NotNull BedWarsPlugin plugin) {
         this.gameMap = mapManager.selectRandom();
-        updateServerInfo();
 
         plugin.getComponentLogger().info(Component.translatable("state.lobby.map",
                 NamedTranslationArgument.component("map", Component.text(gameMap.name()))));
-    }
-
-    private void updateServerInfo() {
-        Bukkit.getServer().motd(Component.text(this.gameMap.name()));
-        Bukkit.getServer().setMaxPlayers(this.gameMap.teams().size() * this.gameMap.teamSize());
     }
 
     private @NotNull Component render(TranslatableComponent component, Locale locale) {

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -93,9 +93,12 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         if (!(this.context.currentState() instanceof LobbyState)) {
             return;
         }
-        event.quitMessage(null);
 
-        this.scoreboards.remove(event.getPlayer());
+        Player player = event.getPlayer();
+
+        event.quitMessage(null);
+        this.scoreboards.get(player).destroy();
+        this.scoreboards.remove(player);
         Bukkit.getScheduler().runTaskLater(this.configuration.plugin(), this::updatePlayerCount, 1L);
     }
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -175,8 +175,11 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     }
 
     private void createScoreboard(@NotNull Player player) {
-        final Locale locale = player.locale();
+        if (this.gameMap == null) {
+            return;
+        }
 
+        final Locale locale = player.locale();
         Scoreboard scoreboard = Scoreboard.builder(DisplayType.SIDEBAR)
                 .player(player)
                 .title(Component.translatable("state.lobby.scoreboard.title"))

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -215,10 +215,10 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     }
 
     private void selectMap(@NotNull BedWarsPlugin plugin) {
-        this.gameMap = mapManager.selectRandom();
-
-        plugin.getComponentLogger().info(Component.translatable("state.lobby.map",
-                NamedTranslationArgument.component("map", Component.text(gameMap.name()))));
+        if ((this.gameMap = mapManager.selectRandom()) == null) {
+            return;
+        }
+        plugin.getComponentLogger().info(Component.translatable("state.lobby.map", NamedTranslationArgument.component("map", Component.text(gameMap.name()))));
     }
 
     private @NotNull Component render(TranslatableComponent component, Locale locale) {

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -123,20 +123,6 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         event.setCancelled(true);
     }
 
-    private void preparePlayer(@NotNull Player player) {
-        player.setFoodLevel(20);
-        player.setLevel(0);
-        player.setExp(0);
-        player.setHealthScale(20.0D);
-        player.setFlying(false);
-        player.setAllowFlight(false);
-        player.setGameMode(GameMode.ADVENTURE);
-
-        if (this.countdown.isRunning()) {
-            PlayerUtil.updateCountdownInformation(player, this.countdown.duration(), this.countdown.remainingTime());
-        }
-    }
-
     // --------------------- Countdown listener hook ---------------------
 
     @Override
@@ -151,7 +137,28 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         updateScoreboard(4, Component.translatable("state.lobby.scoreboard.countdown.idle"));
     }
 
+    // --------------------- Exposure ---------------------
+
+    public @NotNull MapManager mapManager() {
+        return mapManager;
+    }
+
+
     // --------------------- Private shit ---------------------
+
+    private void preparePlayer(@NotNull Player player) {
+        player.setFoodLevel(20);
+        player.setLevel(0);
+        player.setExp(0);
+        player.setHealthScale(20.0D);
+        player.setFlying(false);
+        player.setAllowFlight(false);
+        player.setGameMode(GameMode.ADVENTURE);
+
+        if (this.countdown.isRunning()) {
+            PlayerUtil.updateCountdownInformation(player, this.countdown.duration(), this.countdown.remainingTime());
+        }
+    }
 
     private int calculateMinPlayers() {
         double factor = this.configuration.main().minPlayers();

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -41,7 +41,7 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     private final Configuration configuration;
     private final LobbyCountdown countdown;
     private final MapManager mapManager;
-    private GameMap gameMap;
+    private GameMap gameMap; // The selected map that was set in the MapManager
 
     public LobbyState(@NotNull BedWarsPlugin plugin, GameStateContext context) {
         super(context);

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -143,6 +143,9 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         return mapManager;
     }
 
+    public @NotNull Map<Player, Scoreboard> scoreboards() {
+        return scoreboards;
+    }
 
     // --------------------- Private shit ---------------------
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -146,8 +146,14 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         return mapManager;
     }
 
-    public @NotNull Map<Player, Scoreboard> scoreboards() {
-        return scoreboards;
+    public void updateSelectedMap(GameMap gameMap) {
+        this.gameMap = gameMap;
+    }
+
+    public void updateMapName(@NotNull LobbyState lobbyState) {
+        updateScoreboard(1, Component.translatable("state.lobby.scoreboard.map",
+                NamedTranslationArgument.component("name", Component.text(lobbyState.mapManager().selected().name()))
+        ));
     }
 
     // --------------------- Private shit ---------------------

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -41,7 +41,7 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     private final Configuration configuration;
     private final LobbyCountdown countdown;
     private final MapManager mapManager;
-    private GameMap gameMap; // The selected map that was set in the MapManager
+    private GameMap gameMap;
 
     public LobbyState(@NotNull BedWarsPlugin plugin, GameStateContext context) {
         super(context);
@@ -221,10 +221,11 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     }
 
     private void selectMap(@NotNull BedWarsPlugin plugin) {
-        if ((this.gameMap = mapManager.selectRandom()) == null) {
+        if (this.mapManager.selectRandom() == null) {
             return;
         }
-        plugin.getComponentLogger().info(Component.translatable("state.lobby.map", NamedTranslationArgument.component("map", Component.text(gameMap.name()))));
+        this.gameMap = this.mapManager.selected();
+        plugin.getComponentLogger().info(Component.translatable("state.lobby.map", NamedTranslationArgument.component("map", Component.text(this.gameMap.name()))));
     }
 
     private @NotNull Component render(TranslatableComponent component, Locale locale) {

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -221,10 +221,9 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     }
 
     private void selectMap(@NotNull BedWarsPlugin plugin) {
-        if (this.mapManager.selectRandom() == null) {
+        if ((this.gameMap = this.mapManager.selectRandom()) == null) {
             return;
         }
-        this.gameMap = this.mapManager.selected();
         plugin.getComponentLogger().info(Component.translatable("state.lobby.map", NamedTranslationArgument.component("map", Component.text(this.gameMap.name()))));
     }
 

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -35,6 +35,7 @@ command.createmap.description = Erstellt eine neue Map (Lobby/GameMap)
 command.forcemap.description = Legt eine bestimmte GameMap für die Runde fest
 command.forcemap.error.gamestate = <red>Du kannst diesen Befehl nur während der Lobbyphase nutzen!
 command.forcemap.error.used = <red>Die Map wurde bereits neu festgelegt.
+command.forcemap.error.same = <red>Du kannst nicht die bereits ausgewählte Map nochmal wählen.
 command.forcemap.success = <green>Du hast die Karte auf <gold><name> <green>festgelegt.
 
 # Nachrichten, die zum Spielgeschehen gehören

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -32,6 +32,10 @@ team.pink = <color:#ff6ef8>Team Pink
 # Nachrichten, die zu Befehlen gehören
 command.testgui.description = Öffnet ohne Kontext die GUI
 command.createmap.description = Erstellt eine neue Map (Lobby/GameMap)
+command.forcemap.description = Legt eine bestimmte GameMap für die Runde fest
+command.forcemap.error.gamestate = <red>Du kannst diesen Befehl nur während der Lobbyphase nutzen!
+command.forcemap.error.used = <red>Die Map wurde bereits neu festgelegt.
+command.forcemap.success = <green>Du hast die Karte auf <gold><name> <green>festgelegt.
 
 # Nachrichten, die zum Spielgeschehen gehören
 state.lobby.start = Die Lobbyphase ist gestartet. Spieler können nun beitreten.


### PR DESCRIPTION
# Description

Fügt die Funktion von Forcemapping über einen Befehl hinzu, welcher nicht in der Development-Umgebung verfügbar ist. 

Der Befehl kann einmalig während der Lobbyphase erfolgreich benutzt werden. Zudem muss eine neue Karte ausgewählt werden als jene, die aktuell eingestellt ist. Alle verfügbaren Mapnamen des Matchmakings werden in der Tab-Completion angezeigt.

Die MOTD des Servers wird ebenfalls auf den neuen Mapnamen aktualisiert.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes