### PR TITLE
Add team allocation

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/game/team/Team.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/Team.java
@@ -1,5 +1,30 @@
 package net.alphalightning.bedwars.game.team;
 
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class Team {
 
+    private final List<Player> players = new ArrayList<>();
+    private final JacksonTeam backed;
+
+    public Team(JacksonTeam backedTeam) {
+        this.backed = backedTeam;
+    }
+
+    public void addPlayer(@NotNull Player player) {
+        this.players.add(player);
+    }
+
+    public @NotNull String name() {
+        return this.backed.name();
+    }
+
+    public @NotNull List<Player> players() {
+        return this.players;
+    }
 }

--- a/src/main/java/net/alphalightning/bedwars/game/team/Team.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/Team.java
@@ -1,0 +1,5 @@
+package net.alphalightning.bedwars.game.team;
+
+public class Team {
+
+}

--- a/src/main/java/net/alphalightning/bedwars/game/team/TeamFactory.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/TeamFactory.java
@@ -3,12 +3,18 @@ package net.alphalightning.bedwars.game.team;
 import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TeamFactory {
 
-    public static List<Team> createTeams(@NotNull List<JacksonTeam> jacksonTeams) {
-        return jacksonTeams.stream().map(Team::new).toList();
+    public static @NotNull List<Team> createTeams(@NotNull List<JacksonTeam> jacksonTeams) {
+        List<Team> list = new ArrayList<>();
+        for (JacksonTeam jacksonTeam : jacksonTeams) {
+            Team team = new Team(jacksonTeam);
+            list.add(team);
+        }
+        return list;
     }
 
 }

--- a/src/main/java/net/alphalightning/bedwars/game/team/TeamFactory.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/TeamFactory.java
@@ -1,0 +1,14 @@
+package net.alphalightning.bedwars.game.team;
+
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class TeamFactory {
+
+    public static List<Team> createTeams(@NotNull List<JacksonTeam> jacksonTeams) {
+        return jacksonTeams.stream().map(Team::new).toList();
+    }
+
+}

--- a/src/main/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocator.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocator.java
@@ -1,6 +1,8 @@
 package net.alphalightning.bedwars.game.team.allocator;
 
 import net.alphalightning.bedwars.game.team.Team;
+import net.alphalightning.bedwars.game.team.TeamFactory;
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,12 +11,25 @@ import java.util.List;
 
 public class DynamicTeamAllocator implements TeamAllocator {
 
+    private final List<JacksonTeam> jacksonTeams;
+
+    public DynamicTeamAllocator(List<JacksonTeam> jacksonTeams) {
+        this.jacksonTeams = jacksonTeams;
+    }
+
     @Override
     public @NotNull List<Team> allocateTeams(@NotNull List<Player> players, int maxTeams, int maxTeamSize) {
-        Collections.shuffle(players);
-        TeamConfig config = calculateOptimalConfig(players.size(), maxTeams, maxTeamSize);
+        Collections.shuffle(players); // Randomize players to avoid knowing the teams during the lobby phase
 
-        return List.of();
+        TeamConfig config = calculateOptimalConfig(players.size(), maxTeams, maxTeamSize); // Calculate optimal config
+        List<Team> teams = TeamFactory.createTeams(this.jacksonTeams); // Create actual teams from backed jackson team
+
+        for (int i = 0; i < players.size(); i++) {
+            int index = i % config.teamCount();
+            teams.get(index).addPlayer(players.get(i));
+        }
+
+        return teams;
     }
 
     /**
@@ -63,7 +78,7 @@ public class DynamicTeamAllocator implements TeamAllocator {
      * @return true, wenn die neue Konfiguration besser ist, sonst false.
      */
     private boolean isBetterConfig(@NotNull TeamConfig current, @NotNull TeamConfig best) {
-        return current.teamSize > best.teamSize || (current.teamSize == best.teamSize && current.teamCount < best.teamCount);
+        return current.teamSize() > best.teamSize() || (current.teamSize() == best.teamSize() && current.teamCount() < best.teamCount());
     }
 
     /**

--- a/src/main/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocator.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocator.java
@@ -18,7 +18,7 @@ public class DynamicTeamAllocator implements TeamAllocator {
     }
 
     @Override
-    public @NotNull List<Team> allocateTeams(@NotNull List<Player> players, int maxTeams, int maxTeamSize) {
+    public @NotNull List<Team> allocateTeams(@NotNull List<? extends Player> players, int maxTeams, int maxTeamSize) {
         Collections.shuffle(players); // Randomize players to avoid knowing the teams during the lobby phase
 
         TeamConfig config = calculateOptimalConfig(players.size(), maxTeams, maxTeamSize); // Calculate optimal config

--- a/src/main/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocator.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocator.java
@@ -1,0 +1,74 @@
+package net.alphalightning.bedwars.game.team.allocator;
+
+import net.alphalightning.bedwars.game.team.Team;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DynamicTeamAllocator implements TeamAllocator {
+
+    @Override
+    public @NotNull List<Team> allocateTeams(@NotNull List<Player> players, int maxTeams, int maxTeamSize) {
+        Collections.shuffle(players);
+        TeamConfig config = calculateOptimalConfig(players.size(), maxTeams, maxTeamSize);
+
+        return List.of();
+    }
+
+    /**
+     * Berechnet basierend auf der Gesamtzahl der Spieler, der maximalen Teamanzahl und der maximalen Teamgröße
+     * die optimale Konfiguration (Anzahl der Teams und benötigte Spieler pro Team).
+     * Das Auswahlkriterium ist, dass die Teams so groß wie möglich werden und gleichmäßig aufgeteilt sind.
+     *
+     * @param totalPlayers Gesamtzahl der verfügbaren Spieler.
+     * @param maxTeams     Maximale Anzahl an Teams.
+     * @param maxTeamSize  Maximale Anzahl an Spielern pro Team.
+     * @return Optimale Teamkonfiguration.
+     */
+    private @NotNull TeamConfig calculateOptimalConfig(int totalPlayers, int maxTeams, int maxTeamSize) {
+        TeamConfig bestConfig = null;
+
+        for (int count = 1; count <= maxTeams; count++) {
+            int teamSize = (int) Math.ceil((double) totalPlayers / count);
+
+            // If calculated team size is bigger than the actual max size we want to skip this calculation
+            if (teamSize > maxTeamSize) {
+                continue;
+            }
+
+            TeamConfig config = new TeamConfig(count, teamSize);
+
+            // If no best config exists or a better one was found update it
+            if (bestConfig == null || isBetterConfig(config, bestConfig)) {
+                bestConfig = config;
+            }
+        }
+
+        // Fallback: No suitable config was found -> using standard the config
+        return bestConfig != null ? bestConfig : new TeamConfig(maxTeams, maxTeamSize);
+    }
+
+    /**
+     * Vergleicht zwei Teamkonfigurationen und entscheidet, ob die neue Konfiguration besser ist.
+     * Eine Konfiguration wird als besser betrachtet, wenn:
+     * <ul>
+     *     <li>Sie eine größere Teamgröße hat</li>
+     *     <li>Bei gleicher Teamgröße eine geringere Anzahl an Teams verwendet wird</li>
+     * </ul>
+     *
+     * @param current Die zu prüfende neue Teamkonfiguration.
+     * @param best    Die bisher beste gefundene Teamkonfiguration.
+     * @return true, wenn die neue Konfiguration besser ist, sonst false.
+     */
+    private boolean isBetterConfig(@NotNull TeamConfig current, @NotNull TeamConfig best) {
+        return current.teamSize > best.teamSize || (current.teamSize == best.teamSize && current.teamCount < best.teamCount);
+    }
+
+    /**
+     * Hilfsklasse zur Speicherung der Teamkonfiguration.
+     */
+    private record TeamConfig(int teamCount, int teamSize) {
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/game/team/allocator/TeamAllocator.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/allocator/TeamAllocator.java
@@ -1,0 +1,13 @@
+package net.alphalightning.bedwars.game.team.allocator;
+
+import net.alphalightning.bedwars.game.team.Team;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface TeamAllocator {
+
+    @NotNull List<Team> allocateTeams(@NotNull List<Player> players, int maxTeams, int maxTeamSize);
+
+}

--- a/src/main/java/net/alphalightning/bedwars/game/team/allocator/TeamAllocator.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/allocator/TeamAllocator.java
@@ -16,6 +16,6 @@ public interface TeamAllocator {
      * @param maxTeamSize Maximale Spieleranzahl pro Team.
      * @return Liste der Teams mit zugeordneten Spielern.
      */
-    @NotNull List<Team> allocateTeams(@NotNull List<Player> players, int maxTeams, int maxTeamSize);
+    @NotNull List<Team> allocateTeams(@NotNull List<? extends Player> players, int maxTeams, int maxTeamSize);
 
 }

--- a/src/main/java/net/alphalightning/bedwars/game/team/allocator/TeamAllocator.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/allocator/TeamAllocator.java
@@ -8,6 +8,14 @@ import java.util.List;
 
 public interface TeamAllocator {
 
+    /**
+     * Teilt die Spieler in Teams anhand der optimalen Konfiguration auf.
+     *
+     * @param players    Liste der Spieler.
+     * @param maxTeams   Maximale Anzahl an Teams.
+     * @param maxTeamSize Maximale Spieleranzahl pro Team.
+     * @return Liste der Teams mit zugeordneten Spielern.
+     */
     @NotNull List<Team> allocateTeams(@NotNull List<Player> players, int maxTeams, int maxTeamSize);
 
 }

--- a/src/main/java/net/alphalightning/bedwars/setup/map/GameMapSetup.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/GameMapSetup.java
@@ -4,8 +4,8 @@ import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.game.SpawnerType;
 import net.alphalightning.bedwars.setup.map.jackson.GameMap;
 import net.alphalightning.bedwars.setup.map.jackson.JacksonLocation;
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
 import net.alphalightning.bedwars.setup.map.jackson.SimpleJacksonLocation;
-import net.alphalightning.bedwars.setup.map.jackson.Team;
 import net.alphalightning.bedwars.setup.map.stages.CancelStage;
 import net.alphalightning.bedwars.setup.map.stages.CompleteSetupStage;
 import net.alphalightning.bedwars.setup.map.stages.WelcomeStage;
@@ -49,7 +49,7 @@ public final class GameMapSetup implements MapSetup {
 
     // Configuration
     private final HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner = new HashMap<>();
-    private final List<Team> teams = new ArrayList<>();
+    private final List<JacksonTeam> teams = new ArrayList<>();
     private final List<SimpleJacksonLocation> shopVillagerLocations = new ArrayList<>();
     private final List<SimpleJacksonLocation> upgradeVillagerLocations = new ArrayList<>();
     private JacksonLocation spectatorSpawn;
@@ -129,7 +129,7 @@ public final class GameMapSetup implements MapSetup {
         return stage;
     }
 
-    public List<Team> teams() {
+    public List<JacksonTeam> teams() {
         return teams;
     }
 
@@ -151,7 +151,7 @@ public final class GameMapSetup implements MapSetup {
 
     // Start data manipulation logics
 
-    public void configureTeams(List<Team> teams) {
+    public void configureTeams(List<JacksonTeam> teams) {
         this.teams.addAll(teams);
     }
 

--- a/src/main/java/net/alphalightning/bedwars/setup/map/jackson/GameMap.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/jackson/GameMap.java
@@ -7,7 +7,7 @@ import net.alphalightning.bedwars.game.SpawnerType;
 import java.util.HashMap;
 import java.util.List;
 
-public record GameMap(String name, int teamSize, int minBuildHeight, int maxBuildHeight, boolean slowIron, JacksonLocation spectatorSpawn, List<Team> teams, List<SimpleJacksonLocation> shopVillager, List<SimpleJacksonLocation> upgradeVillager, HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner) {
+public record GameMap(String name, int teamSize, int minBuildHeight, int maxBuildHeight, boolean slowIron, JacksonLocation spectatorSpawn, List<JacksonTeam> teams, List<SimpleJacksonLocation> shopVillager, List<SimpleJacksonLocation> upgradeVillager, HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner) {
 
     @JsonCreator
     public GameMap(
@@ -17,7 +17,7 @@ public record GameMap(String name, int teamSize, int minBuildHeight, int maxBuil
             @JsonProperty("maxBuildHeight") int maxBuildHeight,
             @JsonProperty("slowIron") boolean slowIron,
             @JsonProperty("spectatorSpawn") JacksonLocation spectatorSpawn,
-            @JsonProperty("teams") List<Team> teams,
+            @JsonProperty("teams") List<JacksonTeam> teams,
             @JsonProperty("shopVillager") List<SimpleJacksonLocation> shopVillager,
             @JsonProperty("upgradeVillager") List<SimpleJacksonLocation> upgradeVillager,
             @JsonProperty("spawner") HashMap<SpawnerType, List<SimpleJacksonLocation>> spawner) {

--- a/src/main/java/net/alphalightning/bedwars/setup/map/jackson/JacksonTeam.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/jackson/JacksonTeam.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bukkit.Location;
 
-public class Team {
+public class JacksonTeam {
 
     @JsonIgnore private final int color;
 
@@ -16,23 +16,22 @@ public class Team {
     private SimpleJacksonLocation bedTopHalf;
     private SimpleJacksonLocation lootspawner;
 
-
     @JsonCreator
-    public Team(@JsonProperty("name") String name,
-                @JsonProperty("spawnpoint") JacksonLocation spawnpoint,
-                @JsonProperty("chest") SimpleJacksonLocation chest,
-                @JsonProperty("bedBottomHalf") SimpleJacksonLocation bedBottomHalf,
-                @JsonProperty("bedTopHalf") SimpleJacksonLocation bedTopHalf,
-                @JsonProperty("lootspawner") SimpleJacksonLocation lootspawner) {
+    public JacksonTeam(@JsonProperty("name") String name,
+                       @JsonProperty("spawnpoint") JacksonLocation spawnpoint,
+                       @JsonProperty("chest") SimpleJacksonLocation chest,
+                       @JsonProperty("bedBottomHalf") SimpleJacksonLocation bedBottomHalf,
+                       @JsonProperty("bedTopHalf") SimpleJacksonLocation bedTopHalf,
+                       @JsonProperty("lootspawner") SimpleJacksonLocation lootspawner) {
 
         this(name, -1, spawnpoint, chest, bedBottomHalf, bedTopHalf, lootspawner);
     }
 
-    public Team(String name, int color) {
+    public JacksonTeam(String name, int color) {
         this(name, color, null, null, null, null, null);
     }
 
-    public Team(String name, int color, JacksonLocation spawnpoint, SimpleJacksonLocation chest, SimpleJacksonLocation bedBottomHalf, SimpleJacksonLocation bedTopHalf, SimpleJacksonLocation lootspawner) {
+    public JacksonTeam(String name, int color, JacksonLocation spawnpoint, SimpleJacksonLocation chest, SimpleJacksonLocation bedBottomHalf, SimpleJacksonLocation bedTopHalf, SimpleJacksonLocation lootspawner) {
         this.color = color;
         this.name = name;
         this.spawnpoint = spawnpoint;

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/BedConfigurationStage.java
@@ -8,7 +8,7 @@ import net.alphalightning.bedwars.feedback.visual.renderer.EntityRenderer;
 import net.alphalightning.bedwars.feedback.visual.renderer.EntityVisualization;
 import net.alphalightning.bedwars.setup.map.GameMapSetup;
 import net.alphalightning.bedwars.setup.map.MapSetup;
-import net.alphalightning.bedwars.setup.map.jackson.Team;
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
 import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
@@ -29,12 +29,12 @@ import java.util.List;
 public class BedConfigurationStage extends Stage implements TeamConfiguration, LocationConfiguration {
 
     private final VisualizationManager visualizationManager = VisualizationManager.instance();
-    private final List<Team> teams;
+    private final List<JacksonTeam> teams;
     private final int count;
     private int phase;
 
     private TranslatableComponent teamName = null;
-    private Team team = null;
+    private JacksonTeam team = null;
 
     public BedConfigurationStage(BedWarsPlugin plugin, Player player, MapSetup setup) {
         super(plugin, player, setup);

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamChestConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamChestConfigurationStage.java
@@ -8,7 +8,7 @@ import net.alphalightning.bedwars.feedback.visual.renderer.EntityRenderer;
 import net.alphalightning.bedwars.feedback.visual.renderer.EntityVisualization;
 import net.alphalightning.bedwars.setup.map.GameMapSetup;
 import net.alphalightning.bedwars.setup.map.MapSetup;
-import net.alphalightning.bedwars.setup.map.jackson.Team;
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
 import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
@@ -29,12 +29,12 @@ import java.util.List;
 public class TeamChestConfigurationStage extends Stage implements TeamConfiguration, LocationConfiguration {
 
     private final VisualizationManager visualizationManager = VisualizationManager.instance();
-    private final List<Team> teams;
+    private final List<JacksonTeam> teams;
     private final int count;
     private int phase;
 
     private TranslatableComponent teamName = null;
-    private Team team = null;
+    private JacksonTeam team = null;
 
     public TeamChestConfigurationStage(BedWarsPlugin plugin, Player player, MapSetup setup) {
         super(plugin, player, setup);

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamLootspawnerConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamLootspawnerConfigurationStage.java
@@ -8,7 +8,7 @@ import net.alphalightning.bedwars.feedback.visual.renderer.LootspawnerRenderer;
 import net.alphalightning.bedwars.feedback.visual.renderer.LootspawnerVisualization;
 import net.alphalightning.bedwars.setup.map.GameMapSetup;
 import net.alphalightning.bedwars.setup.map.MapSetup;
-import net.alphalightning.bedwars.setup.map.jackson.Team;
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
 import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
@@ -29,12 +29,12 @@ import java.util.List;
 public class TeamLootspawnerConfigurationStage extends Stage implements TeamConfiguration, LocationConfiguration {
 
     private final VisualizationManager visualizationManager = VisualizationManager.instance();
-    private final List<Team> teams;
+    private final List<JacksonTeam> teams;
     private final int size;
     private int phase;
 
     private TranslatableComponent teamName = null;
-    private Team team = null;
+    private JacksonTeam team = null;
 
     public TeamLootspawnerConfigurationStage(BedWarsPlugin plugin, Player player, MapSetup setup) {
         super(plugin, player, setup);

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamSpawnpointConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/TeamSpawnpointConfigurationStage.java
@@ -8,7 +8,7 @@ import net.alphalightning.bedwars.feedback.visual.renderer.SingleLineRenderer;
 import net.alphalightning.bedwars.feedback.visual.renderer.SingleLineVisualization;
 import net.alphalightning.bedwars.setup.map.GameMapSetup;
 import net.alphalightning.bedwars.setup.map.MapSetup;
-import net.alphalightning.bedwars.setup.map.jackson.Team;
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
 import net.alphalightning.bedwars.setup.map.stages.LocationConfiguration;
 import net.alphalightning.bedwars.setup.map.stages.Stage;
 import net.alphalightning.bedwars.setup.map.stages.TeamConfiguration;
@@ -27,12 +27,12 @@ import java.util.List;
 public class TeamSpawnpointConfigurationStage extends Stage implements TeamConfiguration, LocationConfiguration {
 
     private final VisualizationManager visualizationManager = VisualizationManager.instance();
-    private final List<Team> teams;
+    private final List<JacksonTeam> teams;
     private final int size;
     private int phase;
 
     private TranslatableComponent teamName = null;
-    private Team team = null;
+    private JacksonTeam team = null;
 
     public TeamSpawnpointConfigurationStage(BedWarsPlugin plugin, Player player, MapSetup setup) {
         super(plugin, player, setup);

--- a/src/main/java/net/alphalightning/bedwars/setup/ui/item/SaveConfigurationGuiItem.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/ui/item/SaveConfigurationGuiItem.java
@@ -3,7 +3,7 @@ package net.alphalightning.bedwars.setup.ui.item;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import net.alphalightning.bedwars.feedback.Feedback;
 import net.alphalightning.bedwars.setup.map.GameMapSetup;
-import net.alphalightning.bedwars.setup.map.jackson.Team;
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
 import net.alphalightning.bedwars.setup.ui.SelectTeamsGui;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.translation.GlobalTranslator;
@@ -68,12 +68,12 @@ public class SaveConfigurationGuiItem extends AbstractBoundItem {
         Feedback.success(player);
     }
 
-    private @NotNull List<Team> createTeams() {
-        List<Team> teams = new ArrayList<>();
+    private @NotNull List<JacksonTeam> createTeams() {
+        List<JacksonTeam> teams = new ArrayList<>();
         for (TeamGuiItem teamGuiItem : selectedTeams) {
             int color = teamGuiItem.color();
 
-            Team team = new Team(fromColor(color), color);
+            JacksonTeam team = new JacksonTeam(fromColor(color), color);
             teams.add(team);
         }
 

--- a/src/test/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocatorTest.java
+++ b/src/test/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocatorTest.java
@@ -111,4 +111,24 @@ class DynamicTeamAllocatorTest {
         int totalPlayers = teams.stream().mapToInt(team -> team.players().size()).sum();
         assertEquals(playerCount, totalPlayers, "Alle Spieler müssen korrekt zugewiesen werden.");
     }
+
+    @Test
+    void testMoreTeamsThanPlayers() {
+        List<PlayerMock> players = createPlayerMocks(4);
+        int maxTeams = 4;
+        int maxTeamSize = 2;
+
+        TeamAllocator allocator = new DynamicTeamAllocator(createTeamMocks(maxTeams));
+
+        List<Team> teams = allocator.allocateTeams(players, maxTeams, maxTeamSize);
+        assertEquals(4, teams.size(), "Es sollten vier Teams erstellt sein, auch wenn einige leer sein könnten.");
+
+        int playerCount = 0;
+        for (Team team : teams) {
+            if (!team.players().isEmpty()) {
+                playerCount += team.players().size();
+            }
+        }
+        assertEquals(4, playerCount, "Alle Spieler sollten korrekt in die Teams aufgeteilt sein.");
+    }
 }

--- a/src/test/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocatorTest.java
+++ b/src/test/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocatorTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
@@ -97,4 +98,17 @@ class DynamicTeamAllocatorTest {
         teams.forEach(team -> assertEquals(3, team.players().size(), "Jedes Team sollte genau 3 Spieler haben."));
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {50, 75, 100})
+    void testHighPlayerCounts(int playerCount) {
+        List<PlayerMock> players = createPlayerMocks(playerCount);
+        int maxTeams = 16;
+        int maxTeamSize = 10;
+
+        TeamAllocator allocator = new DynamicTeamAllocator(createTeamMocks(maxTeams));
+        List<Team> teams = allocator.allocateTeams(players, maxTeams, maxTeamSize);
+
+        int totalPlayers = teams.stream().mapToInt(team -> team.players().size()).sum();
+        assertEquals(playerCount, totalPlayers, "Alle Spieler müssen korrekt zugewiesen werden.");
+    }
 }

--- a/src/test/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocatorTest.java
+++ b/src/test/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocatorTest.java
@@ -86,4 +86,15 @@ class DynamicTeamAllocatorTest {
         assertTrue(maxSize - minSize <= 1, "Der Unterschied zwischen Teamgrößen darf maximal 1 sein.");
     }
 
+    @Test
+    void testPerfectMatch() {
+        List<PlayerMock> players = createPlayerMocks(12);
+        int maxTeams = 4;
+        int maxTeamSize = 3;
+
+        TeamAllocator allocator = new DynamicTeamAllocator(createTeamMocks(maxTeams));
+        List<Team> teams = allocator.allocateTeams(players, maxTeams, maxTeamSize);
+        teams.forEach(team -> assertEquals(3, team.players().size(), "Jedes Team sollte genau 3 Spieler haben."));
+    }
+
 }

--- a/src/test/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocatorTest.java
+++ b/src/test/java/net/alphalightning/bedwars/game/team/allocator/DynamicTeamAllocatorTest.java
@@ -1,0 +1,89 @@
+package net.alphalightning.bedwars.game.team.allocator;
+
+import net.alphalightning.bedwars.game.team.Team;
+import net.alphalightning.bedwars.setup.map.jackson.JacksonTeam;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class DynamicTeamAllocatorTest {
+
+    private ServerMock server;
+
+    @BeforeEach
+    void setUp() {
+        this.server = MockBukkit.mock();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    private @NotNull List<JacksonTeam> createTeamMocks(int count) {
+        List<JacksonTeam> teams = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            teams.add(mock(JacksonTeam.class));
+        }
+        return teams;
+    }
+
+    private @NotNull List<PlayerMock> createPlayerMocks(int count) {
+        List<PlayerMock> list = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            PlayerMock playerMock = this.server.addPlayer();
+            list.add(playerMock);
+        }
+        return list;
+    }
+
+    @Test
+    void testEvenTeamDistribution() {
+        List<PlayerMock> players = createPlayerMocks(8);
+        int maxTeams = 4;
+        int maxTeamSize = 2;
+
+        TeamAllocator allocator = new DynamicTeamAllocator(createTeamMocks(maxTeams));
+        List<Team> teams = allocator.allocateTeams(players, maxTeams, maxTeamSize);
+        int totalPlayers = teams.stream().mapToInt(team -> team.players().size()).sum();
+
+        assertEquals(8, totalPlayers, "Alle 8 Spieler müssen verteilt werden.");
+        teams.forEach(team -> assertTrue(team.players().size() <= maxTeamSize, "Kein Team darf mehr als zwei Spieler haben."));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "9, 3, 4", // 9 Spieler auf 3 Teams mit max. 4 Spielern pro Team
+            "11, 4, 3", // 11 Spieler auf 4 Teams mit max. 3 Spielern pro Team
+            "13, 5, 3" // 13 Spieler auf 5 Teams mit max. 3 Spielern pro Team
+    })
+    void testUnevenPlayerCounts(int playerCount, int maxTeams, int maxTeamSize) {
+        List<PlayerMock> players = createPlayerMocks(playerCount);
+
+        TeamAllocator allocator = new DynamicTeamAllocator(createTeamMocks(maxTeams));
+        List<Team> teams = allocator.allocateTeams(players, maxTeams, maxTeamSize);
+
+        // Prüfen, dass alle Spieler einem Team zugewiesen wurden
+        int totalPlayers = teams.stream().mapToInt(team -> team.players().size()).sum();
+        assertEquals(playerCount, totalPlayers, "Alle Spieler müssen korrekt zugewiesen werden.");
+
+        // Prüfen, dass der Unterschied zwischen größten und kleinsten Teams höchstens 1 beträgt
+        int minSize = teams.stream().mapToInt(team -> team.players().size()).filter(value -> value > 0).min().orElse(0);
+        int maxSize = teams.stream().mapToInt(team -> team.players().size()).filter(value -> value > 0).max().orElse(0);
+        assertTrue(maxSize - minSize <= 1, "Der Unterschied zwischen Teamgrößen darf maximal 1 sein.");
+    }
+
+}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fügt eine Funktion hinzu, mit der Spieler in gleichmäßig und faire Teams aufteilt. 
Das Ziel ist es, so große Teams gleichmäßig zu füllen wie nur möglich ist. Beispiel: Matchmaking 4x2 aber nur vier Spieler online 
--> 2 Teams á 2 Spieler ist das Ergebnis

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes