### PR TITLE
[BED-173] Abort countdown if not enough players are online after forcestart

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/game/countdown/Countdown.java
+++ b/src/main/java/net/alphalightning/bedwars/game/countdown/Countdown.java
@@ -90,7 +90,7 @@ public abstract class Countdown {
         tick();
     }
 
-    private void resetCountdown() {
+    public void resetCountdown() {
         state = State.IDLE;
         remainingTime = duration;
         idleTickCounter = 0;
@@ -110,7 +110,7 @@ public abstract class Countdown {
         listeners.forEach(CountdownListener::onEnd);
     }
 
-    private void notifyAbort() {
+    public void notifyAbort() {
         listeners.forEach(CountdownListener::onAbort);
     }
 
@@ -131,6 +131,10 @@ public abstract class Countdown {
 
     public int remainingTime() {
         return remainingTime;
+    }
+
+    public boolean isForceStarted() {
+        return this.isForceStart;
     }
 
     public boolean isRunning() {

--- a/src/main/java/net/alphalightning/bedwars/game/countdown/LobbyCountdown.java
+++ b/src/main/java/net/alphalightning/bedwars/game/countdown/LobbyCountdown.java
@@ -23,6 +23,14 @@ public class LobbyCountdown extends Countdown {
 
     @Override
     protected void onTick(int timeLeft) {
+        if (super.isForceStarted()) {
+            if (!(Bukkit.getOnlinePlayers().size() >= 2)) {
+                onAbort();
+                notifyAbort();
+                resetCountdown();
+                return;
+            }
+        }
         Bukkit.getServer().getOnlinePlayers().forEach(player -> {
             player.clearTitle(); // Make sure a title is displayed for only on countdown tick
 


### PR DESCRIPTION
# Description

Behebt einen Fehler, bei dem der Countdown trotz zu geringer Spielerzahl nach einem Forcestart weitergelaufen ist.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes