### PR TITLE
Premiumjoin

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/config/Configuration.java
+++ b/src/main/java/net/alphalightning/bedwars/config/Configuration.java
@@ -35,6 +35,7 @@ public class Configuration extends JacksonConfig<Default> {
         main().minPlayers(0.8);
         main().forceStartFactor(0.25);
         main().forceStartTime(10);
+        main().premiumJoin(PremiumJoinModus.STACKED);
         save();
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/config/Default.java
+++ b/src/main/java/net/alphalightning/bedwars/config/Default.java
@@ -7,11 +7,11 @@ public class Default {
     private double minPlayers;
     private double forceStartFactor;
     private int forceStartTime;
+    private PremiumJoinModus premiumJoin;
 
     public Environment environment() {
         return environment;
     }
-
 
     public String matchmaking() {
         return matchmaking;
@@ -27,6 +27,10 @@ public class Default {
 
     public int forceStartTime() {
         return forceStartTime;
+    }
+
+    public PremiumJoinModus premiumJoin() {
+        return premiumJoin;
     }
 
     public void environment(Environment environment) {
@@ -47,5 +51,9 @@ public class Default {
 
     public void forceStartTime(int forceStartTime) {
         this.forceStartTime = forceStartTime;
+    }
+
+    public void premiumJoin(PremiumJoinModus premiumJoin) {
+        this.premiumJoin = premiumJoin;
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/config/PremiumJoinModus.java
+++ b/src/main/java/net/alphalightning/bedwars/config/PremiumJoinModus.java
@@ -1,0 +1,7 @@
+package net.alphalightning.bedwars.config;
+
+public enum PremiumJoinModus {
+
+    STACKED, QUEUED, RANDOM
+
+}

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public abstract sealed class PremiumJoin
         implements Listener
@@ -14,6 +15,8 @@ public abstract sealed class PremiumJoin
     protected static final String PREMIUM_PERMISSION = "bedwars.join.premium";
 
     public abstract void onJoin(PlayerJoinEvent event);
+
+    public abstract void onQuit(PlayerQuitEvent event);
 
     public void onLogin(PlayerLoginEvent event) {
         Player player = event.getPlayer();

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -1,10 +1,8 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
-import net.alphalightning.bedwars.BedWarsPlugin;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerLoginEvent;
 
@@ -14,14 +12,6 @@ public abstract sealed class PremiumJoin
 
     protected static final String PREMIUM_PERMISSION = "bedwars.join.premium";
 
-    protected final BedWarsPlugin plugin;
-
-    public PremiumJoin(BedWarsPlugin plugin) {
-        this.plugin = plugin;
-        Bukkit.getPluginManager().registerEvents(this, plugin);
-    }
-
-    @EventHandler
     public void onLogin(PlayerLoginEvent event) {
         Player player = event.getPlayer();
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -15,7 +15,10 @@ public abstract sealed class PremiumJoin
     public void onLogin(PlayerLoginEvent event) {
         Player player = event.getPlayer();
 
-        if (!isServerFull()) return;
+        if (!isServerFull()) {
+            event.allow();
+            return;
+        }
         if (!player.hasPermission(PREMIUM_PERMISSION)) return;
 
         Player kickable = findKickablePlayer();

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -1,6 +1,7 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.translation.GlobalTranslator;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -30,7 +31,7 @@ public abstract sealed class PremiumJoin
         Player kickable = findKickablePlayer();
         if (kickable == null) return;
 
-        kickable.kick(Component.translatable("state.lobby.kick"));
+        kickable.kick(GlobalTranslator.render(Component.translatable("state.lobby.kick"), player.locale()));
         event.allow();
     }
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -1,14 +1,18 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerLoginEvent;
 
 public abstract sealed class PremiumJoin
         implements Listener
         permits QueuedPremiumJoin, RandomizedPremiumJoin, StackedPremiumJoin {
+
+    protected static final String PREMIUM_PERMISSION = "bedwars.join.premium";
 
     protected final BedWarsPlugin plugin;
 
@@ -17,11 +21,27 @@ public abstract sealed class PremiumJoin
         Bukkit.getPluginManager().registerEvents(this, plugin);
     }
 
-    public abstract void onLogin(PlayerLoginEvent event);
+    @EventHandler
+    public void onLogin(PlayerLoginEvent event) {
+        Player player = event.getPlayer();
+
+        if (!isServerFull()) return;
+        if (!player.hasPermission(PREMIUM_PERMISSION)) return;
+
+        Player kickable = findKickablePlayer();
+        if (kickable == null) return;
+
+        kickable.kick(Component.translatable("lobby.kick.premium"));
+        event.allow();
+    }
 
     public abstract Player findKickablePlayer();
 
-    public boolean isServerFull() {
+    public boolean isPlayerKickable(Player player) {
+        return player != null && player.hasPermission(PREMIUM_PERMISSION);
+    }
+
+    private boolean isServerFull() {
         return Bukkit.getOnlinePlayers().size() >= Bukkit.getMaxPlayers();
     }
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -30,15 +30,11 @@ public abstract sealed class PremiumJoin
         Player kickable = findKickablePlayer();
         if (kickable == null) return;
 
-        kickable.kick(Component.translatable("lobby.kick.premium"));
+        kickable.kick(Component.translatable("state.lobby.kick"));
         event.allow();
     }
 
     public abstract Player findKickablePlayer();
-
-    public boolean isPlayerKickable(Player player) {
-        return player != null && !player.hasPermission(PREMIUM_PERMISSION);
-    }
 
     private boolean isServerFull() {
         return Bukkit.getOnlinePlayers().size() >= Bukkit.getMaxPlayers();

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -37,7 +37,7 @@ public abstract sealed class PremiumJoin
     public abstract Player findKickablePlayer();
 
     public boolean isPlayerKickable(Player player) {
-        return player != null && player.hasPermission(PREMIUM_PERMISSION);
+        return player != null && !player.hasPermission(PREMIUM_PERMISSION);
     }
 
     private boolean isServerFull() {

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 
 public abstract sealed class PremiumJoin
@@ -11,6 +12,8 @@ public abstract sealed class PremiumJoin
         permits QueuedPremiumJoin, RandomizedPremiumJoin, StackedPremiumJoin {
 
     protected static final String PREMIUM_PERMISSION = "bedwars.join.premium";
+
+    public abstract void onJoin(PlayerJoinEvent event);
 
     public void onLogin(PlayerLoginEvent event) {
         Player player = event.getPlayer();

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/PremiumJoin.java
@@ -1,0 +1,28 @@
+package net.alphalightning.bedwars.game.state.lobby;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerLoginEvent;
+
+public abstract sealed class PremiumJoin
+        implements Listener
+        permits QueuedPremiumJoin, RandomizedPremiumJoin, StackedPremiumJoin {
+
+    protected final BedWarsPlugin plugin;
+
+    public PremiumJoin(BedWarsPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public abstract void onLogin(PlayerLoginEvent event);
+
+    public abstract Player findKickablePlayer();
+
+    public boolean isServerFull() {
+        return Bukkit.getOnlinePlayers().size() >= Bukkit.getMaxPlayers();
+    }
+
+}

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
@@ -1,0 +1,21 @@
+package net.alphalightning.bedwars.game.state.lobby;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerLoginEvent;
+
+public final class QueuedPremiumJoin extends PremiumJoin {
+
+    public QueuedPremiumJoin(BedWarsPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void onLogin(PlayerLoginEvent event) {
+    }
+
+    @Override
+    public Player findKickablePlayer() {
+        return null;
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
@@ -2,6 +2,7 @@ package net.alphalightning.bedwars.game.state.lobby;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -15,6 +16,10 @@ public final class QueuedPremiumJoin extends PremiumJoin {
         queue.add(event.getPlayer());
     }
 
+    @Override
+    public void onQuit(PlayerQuitEvent event) {
+        queue.remove(event.getPlayer());
+    }
 
     @Override
     public Player findKickablePlayer() {

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
@@ -1,6 +1,5 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
-import net.alphalightning.bedwars.BedWarsPlugin;
 import org.bukkit.entity.Player;
 
 import java.util.Queue;
@@ -9,10 +8,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public final class QueuedPremiumJoin extends PremiumJoin {
 
     private final Queue<Player> queue = new ConcurrentLinkedQueue<>();
-
-    public QueuedPremiumJoin(BedWarsPlugin plugin) {
-        super(plugin);
-    }
 
     @Override
     public Player findKickablePlayer() {

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
@@ -1,6 +1,7 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -8,6 +9,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public final class QueuedPremiumJoin extends PremiumJoin {
 
     private final Queue<Player> queue = new ConcurrentLinkedQueue<>();
+
+    @Override
+    public void onJoin(PlayerJoinEvent event) {
+        queue.add(event.getPlayer());
+    }
+
 
     @Override
     public Player findKickablePlayer() {

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
@@ -2,20 +2,32 @@ package net.alphalightning.bedwars.game.state.lobby;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerLoginEvent;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public final class QueuedPremiumJoin extends PremiumJoin {
+
+    private final Queue<Player> queue = new ConcurrentLinkedQueue<>();
 
     public QueuedPremiumJoin(BedWarsPlugin plugin) {
         super(plugin);
     }
 
     @Override
-    public void onLogin(PlayerLoginEvent event) {
-    }
-
-    @Override
     public Player findKickablePlayer() {
+        int queueSize = queue.size();
+
+        for (int i = 0; i < queueSize; i++) {
+            Player kickable = queue.poll();
+
+            if (isPlayerKickable(kickable)) {
+                return kickable;
+            }
+            if (kickable != null) {
+                queue.add(kickable);
+            }
+        }
         return null;
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/QueuedPremiumJoin.java
@@ -13,7 +13,10 @@ public final class QueuedPremiumJoin extends PremiumJoin {
 
     @Override
     public void onJoin(PlayerJoinEvent event) {
-        queue.add(event.getPlayer());
+        Player player = event.getPlayer();
+        if (!player.hasPermission(PREMIUM_PERMISSION)) {
+            queue.add(event.getPlayer());
+        }
     }
 
     @Override
@@ -23,18 +26,6 @@ public final class QueuedPremiumJoin extends PremiumJoin {
 
     @Override
     public Player findKickablePlayer() {
-        int queueSize = queue.size();
-
-        for (int i = 0; i < queueSize; i++) {
-            Player kickable = queue.poll();
-
-            if (isPlayerKickable(kickable)) {
-                return kickable;
-            }
-            if (kickable != null) {
-                queue.add(kickable);
-            }
-        }
-        return null;
+        return queue.isEmpty() ? null : queue.peek();
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
@@ -1,8 +1,13 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 public final class RandomizedPremiumJoin extends PremiumJoin {
+
+    @Override
+    public void onJoin(PlayerJoinEvent event) {
+    }
 
     @Override
     public Player findKickablePlayer() {

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
@@ -15,8 +15,9 @@ public final class RandomizedPremiumJoin extends PremiumJoin {
 
     @Override
     public void onJoin(PlayerJoinEvent event) {
-        if (!event.getPlayer().hasPermission(PREMIUM_PERMISSION)) {
-            list.add(event.getPlayer());
+        Player player = event.getPlayer();
+        if (!player.hasPermission(PREMIUM_PERMISSION)) {
+            list.add(player);
         }
     }
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
@@ -4,19 +4,31 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 public final class RandomizedPremiumJoin extends PremiumJoin {
+
+    private final List<Player> list = new ArrayList<>();
+
 
     @Override
     public void onJoin(PlayerJoinEvent event) {
+        if (!event.getPlayer().hasPermission(PREMIUM_PERMISSION)) {
+            list.add(event.getPlayer());
+        }
     }
 
     @Override
     public void onQuit(PlayerQuitEvent event) {
-
+        list.remove(event.getPlayer());
     }
 
     @Override
     public Player findKickablePlayer() {
-        return null;
+        Random random = new Random();
+        return list.get(random.nextInt(list.size()));
     }
+
 }

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
@@ -1,0 +1,21 @@
+package net.alphalightning.bedwars.game.state.lobby;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerLoginEvent;
+
+public final class RandomizedPremiumJoin extends PremiumJoin {
+
+    public RandomizedPremiumJoin(BedWarsPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void onLogin(PlayerLoginEvent event) {
+    }
+
+    @Override
+    public Player findKickablePlayer() {
+        return null;
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
@@ -1,18 +1,8 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
-import net.alphalightning.bedwars.BedWarsPlugin;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerLoginEvent;
 
 public final class RandomizedPremiumJoin extends PremiumJoin {
-
-    public RandomizedPremiumJoin(BedWarsPlugin plugin) {
-        super(plugin);
-    }
-
-    @Override
-    public void onLogin(PlayerLoginEvent event) {
-    }
 
     @Override
     public Player findKickablePlayer() {

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/RandomizedPremiumJoin.java
@@ -2,11 +2,17 @@ package net.alphalightning.bedwars.game.state.lobby;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public final class RandomizedPremiumJoin extends PremiumJoin {
 
     @Override
     public void onJoin(PlayerJoinEvent event) {
+    }
+
+    @Override
+    public void onQuit(PlayerQuitEvent event) {
+
     }
 
     @Override

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
@@ -4,19 +4,30 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import java.util.Stack;
+
 public final class StackedPremiumJoin extends PremiumJoin {
+
+    private final Stack<Player> stack = new Stack<>();
 
     @Override
     public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        if (!player.hasPermission(PREMIUM_PERMISSION)) {
+            stack.push(player);
+        }
     }
 
     @Override
     public void onQuit(PlayerQuitEvent event) {
-
+        Player player = event.getPlayer();
+        if (!player.hasPermission(PREMIUM_PERMISSION)) {
+            stack.remove(player);
+        }
     }
 
     @Override
     public Player findKickablePlayer() {
-        return null;
+        return stack.isEmpty() ? null : stack.pop();
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
@@ -1,8 +1,13 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 public final class StackedPremiumJoin extends PremiumJoin {
+
+    @Override
+    public void onJoin(PlayerJoinEvent event) {
+    }
 
     @Override
     public Player findKickablePlayer() {

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
@@ -20,14 +20,11 @@ public final class StackedPremiumJoin extends PremiumJoin {
 
     @Override
     public void onQuit(PlayerQuitEvent event) {
-        Player player = event.getPlayer();
-        if (!player.hasPermission(PREMIUM_PERMISSION)) {
-            stack.remove(player);
-        }
+        stack.remove(event.getPlayer());
     }
 
     @Override
     public Player findKickablePlayer() {
-        return stack.isEmpty() ? null : stack.pop();
+        return stack.isEmpty() ? null : stack.peek();
     }
 }

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
@@ -1,0 +1,21 @@
+package net.alphalightning.bedwars.game.state.lobby;
+
+import net.alphalightning.bedwars.BedWarsPlugin;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerLoginEvent;
+
+public final class StackedPremiumJoin extends PremiumJoin {
+
+    public StackedPremiumJoin(BedWarsPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void onLogin(PlayerLoginEvent event) {
+    }
+
+    @Override
+    public Player findKickablePlayer() {
+        return null;
+    }
+}

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
@@ -1,18 +1,8 @@
 package net.alphalightning.bedwars.game.state.lobby;
 
-import net.alphalightning.bedwars.BedWarsPlugin;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerLoginEvent;
 
 public final class StackedPremiumJoin extends PremiumJoin {
-
-    public StackedPremiumJoin(BedWarsPlugin plugin) {
-        super(plugin);
-    }
-
-    @Override
-    public void onLogin(PlayerLoginEvent event) {
-    }
 
     @Override
     public Player findKickablePlayer() {

--- a/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/lobby/StackedPremiumJoin.java
@@ -2,11 +2,17 @@ package net.alphalightning.bedwars.game.state.lobby;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public final class StackedPremiumJoin extends PremiumJoin {
 
     @Override
     public void onJoin(PlayerJoinEvent event) {
+    }
+
+    @Override
+    public void onQuit(PlayerQuitEvent event) {
+
     }
 
     @Override

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -7,6 +7,8 @@ import net.alphalightning.bedwars.game.countdown.LobbyCountdown;
 import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
 import net.alphalightning.bedwars.game.state.GameStateContext;
+import net.alphalightning.bedwars.game.state.lobby.PremiumJoin;
+import net.alphalightning.bedwars.game.state.lobby.QueuedPremiumJoin;
 import net.alphalightning.bedwars.game.state.lobby.StatisticHologram;
 import net.alphalightning.bedwars.setup.map.LobbyConfiguration;
 import net.alphalightning.bedwars.setup.map.jackson.GameMap;
@@ -28,6 +30,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -49,6 +52,7 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     private final Configuration configuration;
     private final LobbyCountdown countdown;
     private final MapManager mapManager;
+    private final PremiumJoin premiumJoin;
     private final Location hologramLocation;
     private GameMap gameMap;
 
@@ -59,6 +63,7 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         this.configuration = plugin.configuration();
         this.countdown = new LobbyCountdown(plugin, context, 30);
         this.mapManager = new MapManager(plugin);
+        this.premiumJoin = new QueuedPremiumJoin();
         this.hologramLocation = loadHologramLocation();
 
         selectMap(plugin);
@@ -81,6 +86,11 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     }
 
     // --------------------- State related event logics ---------------------
+
+    @EventHandler
+    public void onLogin(PlayerLoginEvent event) {
+        premiumJoin.onLogin(event);
+    }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -97,6 +97,8 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         if (!(this.context.currentState() instanceof LobbyState)) {
             return;
         }
+        this.premiumJoin.onJoin(event);
+
         Player player = event.getPlayer();
 
         event.joinMessage(Component.translatable("state.lobby.join",

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -121,6 +121,7 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         if (!(this.context.currentState() instanceof LobbyState)) {
             return;
         }
+        this.premiumJoin.onQuit(event);
 
         Player player = event.getPlayer();
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -2,14 +2,13 @@ package net.alphalightning.bedwars.game.state.states;
 
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.config.Configuration;
+import net.alphalightning.bedwars.config.PremiumJoinModus;
 import net.alphalightning.bedwars.game.countdown.CountdownListener;
 import net.alphalightning.bedwars.game.countdown.LobbyCountdown;
 import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
 import net.alphalightning.bedwars.game.state.GameStateContext;
-import net.alphalightning.bedwars.game.state.lobby.PremiumJoin;
-import net.alphalightning.bedwars.game.state.lobby.RandomizedPremiumJoin;
-import net.alphalightning.bedwars.game.state.lobby.StatisticHologram;
+import net.alphalightning.bedwars.game.state.lobby.*;
 import net.alphalightning.bedwars.setup.map.LobbyConfiguration;
 import net.alphalightning.bedwars.setup.map.jackson.GameMap;
 import net.alphalightning.bedwars.setup.map.jackson.LobbyLocations;
@@ -63,7 +62,7 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         this.configuration = plugin.configuration();
         this.countdown = new LobbyCountdown(plugin, context, 30);
         this.mapManager = new MapManager(plugin);
-        this.premiumJoin = new RandomizedPremiumJoin();
+        this.premiumJoin = loadPremiumJoin();
         this.hologramLocation = loadHologramLocation();
 
         selectMap(plugin);
@@ -196,6 +195,16 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
     }
 
     // --------------------- Internal logic ---------------------
+
+    private PremiumJoin loadPremiumJoin() {
+        PremiumJoinModus premiumJoin = plugin.configuration().main().premiumJoin();
+
+        return switch (premiumJoin) {
+            case STACKED -> new StackedPremiumJoin();
+            case QUEUED -> new QueuedPremiumJoin();
+            case RANDOM -> new RandomizedPremiumJoin();
+        };
+    }
 
     private void preparePlayer(@NotNull Player player) {
         player.setFoodLevel(20);

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -8,7 +8,7 @@ import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
 import net.alphalightning.bedwars.game.state.GameStateContext;
 import net.alphalightning.bedwars.game.state.lobby.PremiumJoin;
-import net.alphalightning.bedwars.game.state.lobby.StackedPremiumJoin;
+import net.alphalightning.bedwars.game.state.lobby.RandomizedPremiumJoin;
 import net.alphalightning.bedwars.game.state.lobby.StatisticHologram;
 import net.alphalightning.bedwars.setup.map.LobbyConfiguration;
 import net.alphalightning.bedwars.setup.map.jackson.GameMap;
@@ -63,7 +63,7 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         this.configuration = plugin.configuration();
         this.countdown = new LobbyCountdown(plugin, context, 30);
         this.mapManager = new MapManager(plugin);
-        this.premiumJoin = new StackedPremiumJoin();
+        this.premiumJoin = new RandomizedPremiumJoin();
         this.hologramLocation = loadHologramLocation();
 
         selectMap(plugin);

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/LobbyState.java
@@ -8,7 +8,7 @@ import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
 import net.alphalightning.bedwars.game.state.GameStateContext;
 import net.alphalightning.bedwars.game.state.lobby.PremiumJoin;
-import net.alphalightning.bedwars.game.state.lobby.QueuedPremiumJoin;
+import net.alphalightning.bedwars.game.state.lobby.StackedPremiumJoin;
 import net.alphalightning.bedwars.game.state.lobby.StatisticHologram;
 import net.alphalightning.bedwars.setup.map.LobbyConfiguration;
 import net.alphalightning.bedwars.setup.map.jackson.GameMap;
@@ -63,7 +63,7 @@ public class LobbyState extends AbstractGameState implements Listener, Countdown
         this.configuration = plugin.configuration();
         this.countdown = new LobbyCountdown(plugin, context, 30);
         this.mapManager = new MapManager(plugin);
-        this.premiumJoin = new QueuedPremiumJoin();
+        this.premiumJoin = new StackedPremiumJoin();
         this.hologramLocation = loadHologramLocation();
 
         selectMap(plugin);

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -61,7 +61,8 @@ state.lobby.scoreboard.countdown.idle = <gray>Warte...
 state.lobby.scoreboard.countdown.running = <gray>Start in <green><time>s
 state.lobby.scoreboard.matchmaking = <gray>Modus: <green><matchmaking>
 state.lobby.scoreboard.url = <yellow>www.deinserver.net
-state.lobby.hologram = <gold>WARNUNG: Die Position für das Statistikenhologramm konnte nicht geladen werden! 
+state.lobby.hologram = <gold>WARNUNG: Die Position für das Statistikenhologramm konnte nicht geladen werden!
+state.lobby.kick = <red>Ein <gold>Premiumspieler<red>, <dark_purple>VIP <red>oder ein <dark_red>Teammitglied red>hat die Runde betreten, weshalb du gekickt wurdest.
 
 state.ingame.start = <yellow>Das Spiel beginnt!
 state.ingame.stop = Die normale Kampfphase ist beendet.

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -62,7 +62,7 @@ state.lobby.scoreboard.countdown.running = <gray>Start in <green><time>s
 state.lobby.scoreboard.matchmaking = <gray>Modus: <green><matchmaking>
 state.lobby.scoreboard.url = <yellow>www.deinserver.net
 state.lobby.hologram = <gold>WARNUNG: Die Position für das Statistikenhologramm konnte nicht geladen werden!
-state.lobby.kick = <red>Ein <gold>Premiumspieler<red>, <dark_purple>VIP <red>oder ein <dark_red>Teammitglied red>hat die Runde betreten, weshalb du gekickt wurdest.
+state.lobby.kick = <red>Ein <gold>Premiumspieler<red>, <dark_purple>VIP <red>oder ein <dark_red>Teammitglied <red>hat die Runde betreten, weshalb du gekickt wurdest.
 
 state.ingame.start = <yellow>Das Spiel beginnt!
 state.ingame.stop = Die normale Kampfphase ist beendet.

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -62,7 +62,7 @@ state.lobby.scoreboard.countdown.running = <gray>Start in <green><time>s
 state.lobby.scoreboard.matchmaking = <gray>Modus: <green><matchmaking>
 state.lobby.scoreboard.url = <yellow>www.deinserver.net
 state.lobby.hologram = <gold>WARNUNG: Die Position für das Statistikenhologramm konnte nicht geladen werden!
-state.lobby.kick = <red>Ein <gold>Premiumspieler<red>, <dark_purple>VIP <red>oder ein <dark_red>Teammitglied <red>hat die Runde betreten, weshalb du gekickt wurdest.
+state.lobby.kick = <red>Ein <gold>Premiumspieler<red>, <dark_purple>VIP <red>oder <dark_red>Teammitglied <red>hat die Runde betreten, weshalb du gekickt wurdest.
 
 state.ingame.start = <yellow>Das Spiel beginnt!
 state.ingame.stop = Die normale Kampfphase ist beendet.


### PR DESCRIPTION
# Description

Diese PR fügt einen Premium-Join während der Lobbyphase hinzu. Spieler mit Berechtigung können normale Spieler kicken, auch wenn der Server voll ist. Dafür wurden drei verschiedene Algorithmen eingeführt:
1. STACKED (standard): Dieser Modus folgt dem LIFO Prinzip (Last In First Out). Der letzte Spieler ohne Rechte ist derjenige, der als erstes bei einem Premium-Join gehen muss.
2. QUEUED (möglicherweise der unfairste):  Dieser Modus folgt dem FIFO Prinzip (First In First Out). Dabei fliegt der zuerst gejointe Spieler ohne Rechte auch zuerst wieder aus der Runde raus.
3. RANDOM: Dieser Modus wählt zufällig einen Spieler ohne Rechte zum kicken aus.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes