### PR TITLE
Give Player Armor and Sword on Game Start

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/game/state/GameStateContext.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/GameStateContext.java
@@ -38,7 +38,7 @@ public class GameStateContext {
 
         this.states = new GameState[2];
         this.states[0] = new LobbyState(plugin, this, mapManager);
-        this.states[1] = new InGameState(this, mapManager);
+        this.states[1] = new InGameState(plugin, this, mapManager);
     }
 
     public void setGameState(int state) {

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -1,5 +1,7 @@
 package net.alphalightning.bedwars.game.state.states;
 
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.DyedItemColor;
 import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
 import net.alphalightning.bedwars.game.state.GameStateContext;
@@ -8,13 +10,10 @@ import net.alphalightning.bedwars.game.team.allocator.DynamicTeamAllocator;
 import net.alphalightning.bedwars.game.team.allocator.TeamAllocator;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.Material;
+import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
+import xyz.xenondevs.invui.item.ItemBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,27 +64,26 @@ public class InGameState extends AbstractGameState {
     }
 
     private void preparePlayers() {
-        ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
-        ItemStack chestplate = new ItemStack(Material.LEATHER_CHESTPLATE);
-        ItemStack leggings = new ItemStack(Material.LEATHER_LEGGINGS);
-        ItemStack boots = new ItemStack(Material.LEATHER_BOOTS);
-
-        LeatherArmorMeta helmetItemMeta = (LeatherArmorMeta) helmet.getItemMeta();
-        LeatherArmorMeta chestplateItemMeta = (LeatherArmorMeta) chestplate.getItemMeta();
-        LeatherArmorMeta leggingsItemMeta = (LeatherArmorMeta) leggings.getItemMeta();
-        LeatherArmorMeta bootsItemMeta = (LeatherArmorMeta) boots.getItemMeta();
 
         for (Team team : teams) {
             int color = team.color();
 
-            helmetItemMeta.setColor(Color.fromRGB(color));
-            chestplateItemMeta.setColor(Color.fromRGB(color));
-            leggingsItemMeta.setColor(Color.fromRGB(color));
-            bootsItemMeta.setColor(Color.fromRGB(color));
+            ItemStack helmet = new ItemBuilder(Material.LEATHER_HELMET)
+                    .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
+                    .build();
+            ItemStack chestplate = new ItemBuilder(Material.LEATHER_CHESTPLATE)
+                    .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
+                    .build();
+            ItemStack leggings = new ItemBuilder(Material.LEATHER_LEGGINGS)
+                    .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
+                    .build();
+            ItemStack boots = new ItemBuilder(Material.LEATHER_BOOTS)
+                    .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
+                    .build();
 
             for (Player player : team.players()) {
                 player.getInventory().setArmorContents(new ItemStack[]{
-                        helmet, chestplate, leggings, boots
+                        boots, leggings, chestplate, helmet
                 });
             }
         }

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -12,13 +12,18 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import org.bukkit.*;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import xyz.xenondevs.invui.item.ItemBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class InGameState extends AbstractGameState {
+public class InGameState extends AbstractGameState implements Listener {
 
     private final MapManager mapManager;
     private List<Team> teams;
@@ -64,7 +69,6 @@ public class InGameState extends AbstractGameState {
     }
 
     private void preparePlayers() {
-
         for (Team team : teams) {
             int color = team.color();
 
@@ -87,6 +91,32 @@ public class InGameState extends AbstractGameState {
                 });
             }
         }
+    }
+
+    @EventHandler
+    public void onDropItem(PlayerDropItemEvent event) {
+        ItemStack item = event.getItemDrop().getItemStack();
+        if (isArmor(item)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        InventoryType.SlotType slotType = event.getSlotType();
+
+        if (slotType == InventoryType.SlotType.ARMOR) {
+            event.setCancelled(true);
+        }
+    }
+
+    private boolean isArmor(ItemStack item) {
+        if (item == null) return false;
+        Material type = item.getType();
+        return switch (type) {
+            case LEATHER_HELMET, LEATHER_CHESTPLATE, LEATHER_LEGGINGS, LEATHER_BOOTS, DIAMOND_BOOTS, DIAMOND_LEGGINGS, CHAINMAIL_BOOTS, CHAINMAIL_LEGGINGS, IRON_BOOTS, IRON_LEGGINGS -> true;
+            default -> false;
+        };
     }
 
 }

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -9,8 +9,12 @@ import net.alphalightning.bedwars.game.team.allocator.TeamAllocator;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +38,7 @@ public class InGameState extends AbstractGameState {
         context.logger().info(component);
         allocateTeams();
         teleportPlayers();
+        preparePlayers();
     }
 
     @Override
@@ -58,4 +63,32 @@ public class InGameState extends AbstractGameState {
             }
         }
     }
+
+    private void preparePlayers() {
+        ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
+        ItemStack chestplate = new ItemStack(Material.LEATHER_CHESTPLATE);
+        ItemStack leggings = new ItemStack(Material.LEATHER_LEGGINGS);
+        ItemStack boots = new ItemStack(Material.LEATHER_BOOTS);
+
+        LeatherArmorMeta helmetItemMeta = (LeatherArmorMeta) helmet.getItemMeta();
+        LeatherArmorMeta chestplateItemMeta = (LeatherArmorMeta) chestplate.getItemMeta();
+        LeatherArmorMeta leggingsItemMeta = (LeatherArmorMeta) leggings.getItemMeta();
+        LeatherArmorMeta bootsItemMeta = (LeatherArmorMeta) boots.getItemMeta();
+
+        for (Team team : teams) {
+            int color = team.color();
+
+            helmetItemMeta.setColor(Color.fromRGB(color));
+            chestplateItemMeta.setColor(Color.fromRGB(color));
+            leggingsItemMeta.setColor(Color.fromRGB(color));
+            bootsItemMeta.setColor(Color.fromRGB(color));
+
+            for (Player player : team.players()) {
+                player.getInventory().setArmorContents(new ItemStack[]{
+                        helmet, chestplate, leggings, boots
+                });
+            }
+        }
+    }
+
 }

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -94,7 +94,9 @@ public class InGameState extends AbstractGameState implements Listener {
                     .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
                     .build();
 
-            ItemStack woodSword = new ItemBuilder(Material.WOODEN_SWORD).build();
+            ItemStack woodSword = new ItemBuilder(Material.WOODEN_SWORD)
+                    .set(DataComponentTypes.UNBREAKABLE, Unbreakable.unbreakable())
+                    .build();
             for (Player player : team.players()) {
                 player.getInventory().setArmorContents(new ItemStack[]{
                         boots, leggings, chestplate, helmet

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -2,6 +2,7 @@ package net.alphalightning.bedwars.game.state.states;
 
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.DyedItemColor;
+import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
 import net.alphalightning.bedwars.game.state.GameStateContext;
@@ -18,6 +19,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import xyz.xenondevs.invui.item.ItemBuilder;
 
 import java.util.ArrayList;
@@ -28,9 +30,11 @@ public class InGameState extends AbstractGameState implements Listener {
     private final MapManager mapManager;
     private List<Team> teams;
 
-    public InGameState(GameStateContext context, MapManager mapManager) {
+    public InGameState(@NotNull BedWarsPlugin plugin, GameStateContext context, MapManager mapManager) {
         super(context);
         this.mapManager = mapManager;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+
     }
 
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -111,6 +111,10 @@ public class InGameState extends AbstractGameState implements Listener {
         ItemStack item = event.getItemDrop().getItemStack();
         if (isArmor(item)) {
             event.setCancelled(true);
+            return;
+        }
+        if (event.getItemDrop().getItemStack().getType() == Material.WOODEN_SWORD) {
+            event.setCancelled(true);
         }
     }
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -94,10 +94,12 @@ public class InGameState extends AbstractGameState implements Listener {
                     .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
                     .build();
 
+            ItemStack woodSword = new ItemBuilder(Material.WOODEN_SWORD).build();
             for (Player player : team.players()) {
                 player.getInventory().setArmorContents(new ItemStack[]{
                         boots, leggings, chestplate, helmet
                 });
+                player.getInventory().setItem(0, woodSword);
             }
         }
     }

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -2,6 +2,7 @@ package net.alphalightning.bedwars.game.state.states;
 
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.DyedItemColor;
+import io.papermc.paper.datacomponent.item.Unbreakable;
 import net.alphalightning.bedwars.BedWarsPlugin;
 import net.alphalightning.bedwars.game.map.MapManager;
 import net.alphalightning.bedwars.game.state.AbstractGameState;
@@ -78,14 +79,18 @@ public class InGameState extends AbstractGameState implements Listener {
 
             ItemStack helmet = new ItemBuilder(Material.LEATHER_HELMET)
                     .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
+                    .set(DataComponentTypes.UNBREAKABLE, Unbreakable.unbreakable())
                     .build();
             ItemStack chestplate = new ItemBuilder(Material.LEATHER_CHESTPLATE)
                     .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
+                    .set(DataComponentTypes.UNBREAKABLE, Unbreakable.unbreakable())
                     .build();
             ItemStack leggings = new ItemBuilder(Material.LEATHER_LEGGINGS)
                     .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
+                    .set(DataComponentTypes.UNBREAKABLE, Unbreakable.unbreakable())
                     .build();
             ItemStack boots = new ItemBuilder(Material.LEATHER_BOOTS)
+                    .set(DataComponentTypes.UNBREAKABLE, Unbreakable.unbreakable())
                     .set(DataComponentTypes.DYED_COLOR, DyedItemColor.dyedItemColor(Color.fromRGB(color), false))
                     .build();
 

--- a/src/main/java/net/alphalightning/bedwars/game/team/Team.java
+++ b/src/main/java/net/alphalightning/bedwars/game/team/Team.java
@@ -32,7 +32,9 @@ public class Team {
     public Location spawnpoint() {
        return this.backed.spawnpoint().asBukkitLocation();
     }
-
+    public int color() {
+        return this.backed.color();
+    }
     @Override
     public String toString() {
         return "Team{" +

--- a/src/main/java/net/alphalightning/bedwars/setup/map/jackson/JacksonTeam.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/jackson/JacksonTeam.java
@@ -1,13 +1,12 @@
 package net.alphalightning.bedwars.setup.map.jackson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bukkit.Location;
 
 public class JacksonTeam {
 
-    @JsonIgnore private final int color;
+    private final int color;
 
     private final String name;
     private JacksonLocation spawnpoint;

--- a/src/main/java/net/alphalightning/bedwars/setup/map/jackson/JacksonTeam.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/jackson/JacksonTeam.java
@@ -6,9 +6,9 @@ import org.bukkit.Location;
 
 public class JacksonTeam {
 
-    private final int color;
 
     private final String name;
+    private final int color;
     private JacksonLocation spawnpoint;
     private SimpleJacksonLocation chest;
     private SimpleJacksonLocation bedBottomHalf;


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Sobald der State zu INGAME wechselt, bekommt der Spieler ein volles Set Lederrüstung in seiner Teamfarbe und ein Holzschwert. Diese Items sind unzerstörbar. Die Rüstung kann nicht gedroppt oder Ausgezogen werden.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes