### PR TITLE
Improve region selection renderings

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/CuboidConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/CuboidConfigurationStage.java
@@ -21,6 +21,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
     private final int count;
     private int phase;
     private boolean undoUsed = false;
+    private BukkitTask currentVisualization;
 
     private final List<CuboidSelection> selections = new ArrayList<>();
     private final SelectionWandTool tool;
@@ -92,8 +94,12 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
         tool.onToolUse(event);
 
         if (!tool.isComplete()) {
+            if (currentVisualization != null) {
+                visualizationManager.removeLastTask(setup);
+            }
+
             Block block = tool.first() != null ? tool.first().getBlock() : tool.second().getBlock();
-            new BoundingBoxRenderer<Block>(plugin, setup).render(block, team.color());
+            currentVisualization = new BoundingBoxRenderer<Block>(plugin, setup).render(block, team.color());
             return;
         }
 

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/CuboidConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/CuboidConfigurationStage.java
@@ -81,7 +81,7 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
     public void onInteract(PlayerInteractEvent event) {
         if (isNotPlayerConfiguring(event.getPlayer())) return;
         if (isNotStage(GameMapSetup.CUBOID_SELECTION_CONFIGURATION_STAGE)) return;
-        if (!(setup instanceof GameMapSetup gameMapSetup)) return;
+        if (!(setup instanceof GameMapSetup)) return;
         if (event.getHand() != EquipmentSlot.HAND) return;
 
         if (selections.size() >= phase) { // Warte auf Bestätigung/Reset der aktuell getroffenen Auswahl
@@ -91,19 +91,25 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
 
         tool.onToolUse(event);
 
-        if (!tool.isComplete()) return;
+        if (!tool.isComplete()) {
+            Block block = tool.first() != null ? tool.first().getBlock() : tool.second().getBlock();
+            new BoundingBoxRenderer<Block>(plugin, setup).render(block, team.color());
+            return;
+        }
+
         if (!tool.first().getWorld().equals(tool.second().getWorld())) {
             player.sendMessage(Component.translatable("mapsetup.stage.16.world"));
             Feedback.error(player);
             return;
         }
+        visualizationManager.removeLastTask(setup); // Remove single block rendering
 
         CuboidSelection selection = new CuboidSelection(tool.first(), tool.second());
 
         undoUsed = false;
         selections.add(selection);
 
-        new BoundingBoxRenderer<List<Block>>(plugin, gameMapSetup).render(selection.corners(), team.color());
+        new BoundingBoxRenderer<List<Block>>(plugin, setup).render(selection.corners(), team.color());
     }
 
     @EventHandler

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/CuboidConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/CuboidConfigurationStage.java
@@ -35,7 +35,7 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
     private final int count;
     private int phase;
     private boolean undoUsed = false;
-    private BukkitTask currentVisualization;
+    private BukkitTask tmpVisualization;
 
     private final List<CuboidSelection> selections = new ArrayList<>();
     private final SelectionWandTool tool;
@@ -67,6 +67,7 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
 
         this.phase = phase;
         this.undoUsed = false;
+
         this.team = teams.get(phase - 1);
         this.teamName = Component.translatable("team." + convertName(team.name()));
 
@@ -94,12 +95,12 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
         tool.onToolUse(event);
 
         if (!tool.isComplete()) {
-            if (currentVisualization != null) {
+            if (tmpVisualization != null) {
                 visualizationManager.removeLastTask(setup);
             }
 
             Block block = tool.first() != null ? tool.first().getBlock() : tool.second().getBlock();
-            currentVisualization = new BoundingBoxRenderer<Block>(plugin, setup).render(block, team.color());
+            tmpVisualization = new BoundingBoxRenderer<Block>(plugin, setup).render(block, team.color());
             return;
         }
 
@@ -108,6 +109,8 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
             Feedback.error(player);
             return;
         }
+
+        tmpVisualization = null;
         visualizationManager.removeLastTask(setup); // Remove single block rendering
 
         CuboidSelection selection = new CuboidSelection(tool.first(), tool.second());

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/CuboidConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/CuboidConfigurationStage.java
@@ -110,9 +110,11 @@ public class CuboidConfigurationStage extends Stage implements TeamConfiguration
             return;
         }
 
+        // Remove single block rendering
         tmpVisualization = null;
-        visualizationManager.removeLastTask(setup); // Remove single block rendering
+        visualizationManager.removeLastTask(setup);
 
+        // Save selection
         CuboidSelection selection = new CuboidSelection(tool.first(), tool.second());
 
         undoUsed = false;

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/SpawnerProtectionConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/SpawnerProtectionConfigurationStage.java
@@ -36,7 +36,7 @@ public class SpawnerProtectionConfigurationStage extends Stage implements Approv
     private final SelectionWandTool tool;
     private final int count;
     private int phase;
-    private BukkitTask currentVisualization;
+    private BukkitTask tmpVisualization;
 
     private boolean undoUsed = false;
 
@@ -91,12 +91,12 @@ public class SpawnerProtectionConfigurationStage extends Stage implements Approv
         tool.onToolUse(event);
 
         if (!tool.isComplete()) {
-            if (currentVisualization != null) {
+            if (tmpVisualization != null) {
                 visualizationManager.removeLastTask(setup);
             }
 
             Block block = tool.first() != null ? tool.first().getBlock() : tool.second().getBlock();
-            currentVisualization = new BoundingBoxRenderer<Block>(plugin, setup).render(block, COLOR);
+            tmpVisualization = new BoundingBoxRenderer<Block>(plugin, setup).render(block, COLOR);
             return;
         }
 
@@ -105,8 +105,12 @@ public class SpawnerProtectionConfigurationStage extends Stage implements Approv
             Feedback.error(player);
             return;
         }
-        visualizationManager.removeLastTask(setup); // Remove single block rendering
 
+        // Remove single block rendering
+        tmpVisualization = null;
+        visualizationManager.removeLastTask(setup);
+
+        // Save selection
         CuboidSelection selection = new CuboidSelection(tool.first(), tool.second());
         RegionInformation information = RegionUtil.createRegionInformation(selection);
 

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/SpawnerProtectionConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/SpawnerProtectionConfigurationStage.java
@@ -21,6 +21,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -35,6 +36,7 @@ public class SpawnerProtectionConfigurationStage extends Stage implements Approv
     private final SelectionWandTool tool;
     private final int count;
     private int phase;
+    private BukkitTask currentVisualization;
 
     private boolean undoUsed = false;
 
@@ -89,8 +91,12 @@ public class SpawnerProtectionConfigurationStage extends Stage implements Approv
         tool.onToolUse(event);
 
         if (!tool.isComplete()) {
+            if (currentVisualization != null) {
+                visualizationManager.removeLastTask(setup);
+            }
+
             Block block = tool.first() != null ? tool.first().getBlock() : tool.second().getBlock();
-            new BoundingBoxRenderer<Block>(plugin, setup).render(block, COLOR);
+            currentVisualization = new BoundingBoxRenderer<Block>(plugin, setup).render(block, COLOR);
             return;
         }
 

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/SpawnerProtectionConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/SpawnerProtectionConfigurationStage.java
@@ -79,7 +79,7 @@ public class SpawnerProtectionConfigurationStage extends Stage implements Approv
     public void onInteract(PlayerInteractEvent event) {
         if (isNotPlayerConfiguring(event.getPlayer())) return;
         if (isNotStage(GameMapSetup.SPAWNER_PROTECTION_CONFIGURATION_STAGE)) return;
-        if (!(setup instanceof GameMapSetup gameMapSetup)) return;
+        if (!(setup instanceof GameMapSetup)) return;
         if (event.getHand() != EquipmentSlot.HAND) return;
 
         if (informationList.size() >= phase) { // Warte auf Bestätigung/Reset der aktuell getroffenen Auswahl

--- a/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/SpawnerProtectionConfigurationStage.java
+++ b/src/main/java/net/alphalightning/bedwars/setup/map/stages/gamemap/SpawnerProtectionConfigurationStage.java
@@ -28,6 +28,8 @@ import java.util.List;
 
 public class SpawnerProtectionConfigurationStage extends Stage implements ApprovableConfiguration {
 
+    private static final int COLOR = Color.fromRGB(0xF06562).asRGB();
+
     private final VisualizationManager visualizationManager = VisualizationManager.instance();
     private final List<RegionInformation> informationList = new ArrayList<>();
     private final SelectionWandTool tool;
@@ -86,19 +88,26 @@ public class SpawnerProtectionConfigurationStage extends Stage implements Approv
         }
         tool.onToolUse(event);
 
-        if (!tool.isComplete()) return;
+        if (!tool.isComplete()) {
+            Block block = tool.first() != null ? tool.first().getBlock() : tool.second().getBlock();
+            new BoundingBoxRenderer<Block>(plugin, setup).render(block, COLOR);
+            return;
+        }
+
         if (!tool.first().getWorld().equals(tool.second().getWorld())) {
             player.sendMessage(Component.translatable("mapsetup.stage.18.error.world"));
             Feedback.error(player);
             return;
         }
+        visualizationManager.removeLastTask(setup); // Remove single block rendering
 
         CuboidSelection selection = new CuboidSelection(tool.first(), tool.second());
         RegionInformation information = RegionUtil.createRegionInformation(selection);
 
         undoUsed = false;
         informationList.add(information);
-        new BoundingBoxRenderer<List<Block>>(plugin, gameMapSetup).render(selection.corners(), Color.fromRGB(0xF06562).asRGB());
+
+        new BoundingBoxRenderer<List<Block>>(plugin, setup).render(selection.corners(), COLOR);
     }
 
     @EventHandler


### PR DESCRIPTION
# Description

Diese PR verbessert bzw. fügt Visualisierungen für Regionauswahlen hinzu. Folgendes Verhalten wurde implementiert:
1. Die zuerst markierte Position wird visualisiert
2. Markiert man die erste Position an zwei verschiedenen Stellen (2x Linksklick) dann verschiebt sich die Visualisierung auf den neuen Block
3. Ist die Auswahl vollständig, wird die komplette Auswahl visualisiert.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes