### PR TITLE
Prevent breaking of blocks not placed by a player

### DIFF
--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -200,7 +200,7 @@ public class InGameState extends AbstractGameState implements Listener {
         Block block = event.getBlock();
 
         if (!(context.currentState() instanceof InGameState)) return;
-        if (block.getState() instanceof Bed) {
+        if (!(block.getBlockData() instanceof Bed)) {
             List<MetadataValue> metadataValues = block.getMetadata("team");
             if (metadataValues.isEmpty()) return;
 
@@ -350,7 +350,6 @@ public class InGameState extends AbstractGameState implements Listener {
                 case "pink" -> Material.PINK_BED;
                 default -> throw new IllegalArgumentException("Unknown team name: " + team.name());
             };
-
             createBed(topHalfLocation, bedMaterial, Bed.Part.HEAD, blockFace, team);
             createBed(bottomHalfLocation, bedMaterial, Bed.Part.FOOT, blockFace, team);
         }

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -147,7 +147,7 @@ public class InGameState extends AbstractGameState implements Listener {
             return;
         }
 
-        if(!event.getPlayer().isSneaking()) {
+        if (!event.getPlayer().isSneaking()) {
             if (clicked.getType().name().endsWith("_BED")) {
                 event.setCancelled(true);
             }
@@ -158,7 +158,7 @@ public class InGameState extends AbstractGameState implements Listener {
     public void onBlockPlace(BlockPlaceEvent event) {
         Block block = event.getBlock();
 
-        if(!(context.currentState() instanceof InGameState)) return;
+        if (!(context.currentState() instanceof InGameState)) return;
 
         placedBlocks.add(block.getLocation());
     }
@@ -170,7 +170,7 @@ public class InGameState extends AbstractGameState implements Listener {
         List<Block> toRemove = new ArrayList<>();
 
         for (Block block : event.blockList()) {
-            if(!placedBlocks.contains(block.getLocation())) {
+            if (!placedBlocks.contains(block.getLocation())) {
                 toRemove.add(block);
                 continue;
             }
@@ -186,7 +186,7 @@ public class InGameState extends AbstractGameState implements Listener {
         List<Block> toRemove = new ArrayList<>();
 
         for (Block block : event.blockList()) {
-            if(!placedBlocks.contains(block.getLocation())) {
+            if (!placedBlocks.contains(block.getLocation())) {
                 toRemove.add(block);
                 continue;
             }
@@ -233,9 +233,9 @@ public class InGameState extends AbstractGameState implements Listener {
             sendDestruction(player, destroyerTeam, destroyedTeam);
             return;
         }
-        if(block.getBlockData() instanceof Fire) return;
+        if (block.getBlockData() instanceof Fire) return;
 
-        if(!placedBlocks.contains(block.getLocation())) {
+        if (!placedBlocks.contains(block.getLocation())) {
             event.setCancelled(true);
         } else {
             placedBlocks.remove(block.getLocation());

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -28,6 +28,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -160,14 +161,35 @@ public class InGameState extends AbstractGameState implements Listener {
     }
 
     @EventHandler
-    public void onBlockExplode(BlockExplodeEvent event) {
-        Block block = event.getBlock();
+    public void onEntityExplode(EntityExplodeEvent event) {
+        if (!(context.currentState() instanceof InGameState)) return;
 
-        if(!placedBlocks.contains(block.getLocation())) {
-            event.setCancelled(true);
-        } else {
+        List<Block> toRemove = new ArrayList<>();
+
+        for (Block block : event.blockList()) {
+            if(!placedBlocks.contains(block.getLocation())) {
+                toRemove.add(block);
+                continue;
+            }
             placedBlocks.remove(block.getLocation());
         }
+        event.blockList().removeAll(toRemove);
+    }
+
+    @EventHandler
+    public void onBlockExplode(BlockExplodeEvent event) {
+        if (!(context.currentState() instanceof InGameState)) return;
+
+        List<Block> toRemove = new ArrayList<>();
+
+        for (Block block : event.blockList()) {
+            if(!placedBlocks.contains(block.getLocation())) {
+                toRemove.add(block);
+                continue;
+            }
+            placedBlocks.remove(block.getLocation());
+        }
+        event.blockList().removeAll(toRemove);
     }
 
     @EventHandler

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -200,7 +200,7 @@ public class InGameState extends AbstractGameState implements Listener {
         Block block = event.getBlock();
 
         if (!(context.currentState() instanceof InGameState)) return;
-        if (block instanceof Bed) {
+        if (block instanceof org.bukkit.block.Bed) {
             List<MetadataValue> metadataValues = block.getMetadata("team");
             if (metadataValues.isEmpty()) return;
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -233,7 +233,7 @@ public class InGameState extends AbstractGameState implements Listener {
             sendDestruction(player, destroyerTeam, destroyedTeam);
             return;
         }
-        if(!(block.getBlockData() instanceof Fire)) return;
+        if(block.getBlockData() instanceof Fire) return;
 
         if(!placedBlocks.contains(block.getLocation())) {
             event.setCancelled(true);

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -26,6 +26,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -41,13 +43,17 @@ import xyz.xenondevs.invui.item.ItemBuilder;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class InGameState extends AbstractGameState implements Listener {
 
     private final BedWarsPlugin plugin;
     private final MapManager mapManager;
     private static List<Team> teams;
+
+    private final Set<Location> placedBlocks = new HashSet<>();
 
     public InGameState(@NotNull BedWarsPlugin plugin, GameStateContext context, MapManager mapManager) {
         super(context);
@@ -76,6 +82,7 @@ public class InGameState extends AbstractGameState implements Listener {
 
     @Override
     public void stop() {
+        placedBlocks.clear();
         context.logger().info(Component.translatable("state.ingame.stop"));
     }
 
@@ -144,41 +151,68 @@ public class InGameState extends AbstractGameState implements Listener {
     }
 
     @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        Block block = event.getBlock();
+
+        if(!(context.currentState() instanceof InGameState)) return;
+
+        placedBlocks.add(block.getLocation());
+    }
+
+    @EventHandler
+    public void onBlockExplode(BlockExplodeEvent event) {
+        Block block = event.getBlock();
+
+        if(!placedBlocks.contains(block.getLocation())) {
+            event.setCancelled(true);
+        } else {
+            placedBlocks.remove(block.getLocation());
+        }
+    }
+
+    @EventHandler
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
         Block block = event.getBlock();
 
         if (!(context.currentState() instanceof InGameState)) return;
+        if (block instanceof Bed) {
+            List<MetadataValue> metadataValues = block.getMetadata("team");
+            if (metadataValues.isEmpty()) return;
 
-        List<MetadataValue> metadataValues = block.getMetadata("team");
-        if (metadataValues.isEmpty()) return;
+            FixedMetadataValue value = (FixedMetadataValue) metadataValues.getFirst();
+            if (value.getOwningPlugin() == null) return;
+            if (!value.getOwningPlugin().equals(plugin)) return;
 
-        FixedMetadataValue value = (FixedMetadataValue) metadataValues.getFirst();
-        if (value.getOwningPlugin() == null) return;
-        if (!value.getOwningPlugin().equals(plugin)) return;
+            Team destroyedTeam = (Team) value.value();
+            Team destroyerTeam = findTeamByPlayer(player);
 
-        Team destroyedTeam = (Team) value.value();
-        Team destroyerTeam = findTeamByPlayer(player);
+            if (destroyedTeam == null) {
+                throw new IllegalStateException("Block " + block.getLocation() + " has no team metadata");
+            }
 
-        if (destroyedTeam == null) {
-            throw new IllegalStateException("Block " + block.getLocation() + " has no team metadata");
-        }
+            if (destroyerTeam == null) {
+                event.setCancelled(true);
+                throw new IllegalStateException("Player " + player.getName() + " is not on a team");
+            }
 
-        if (destroyerTeam == null) {
-            event.setCancelled(true);
-            throw new IllegalStateException("Player " + player.getName() + " is not on a team");
-        }
+            if (destroyerTeam.equals(destroyedTeam)) {
+                player.sendMessage(Component.translatable("state.ingame.break.own"));
+                event.setCancelled(true);
+                return;
+            }
 
-        if (destroyerTeam.equals(destroyedTeam)) {
-            player.sendMessage(Component.translatable("state.ingame.break.own"));
-            event.setCancelled(true);
+            event.setDropItems(false);
+
+            deleteBed(destroyedTeam, value);
+            sendDestruction(player, destroyerTeam, destroyedTeam);
             return;
         }
-
-        event.setDropItems(false);
-
-        deleteBed(destroyedTeam, value);
-        sendDestruction(player, destroyerTeam, destroyedTeam);
+        if(!placedBlocks.contains(block.getLocation())) {
+            event.setCancelled(true);
+        } else {
+            placedBlocks.remove(block.getLocation());
+        }
     }
 
     private void deleteBed(Team team, FixedMetadataValue value) {

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -21,6 +21,7 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Fire;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -232,6 +233,8 @@ public class InGameState extends AbstractGameState implements Listener {
             sendDestruction(player, destroyerTeam, destroyedTeam);
             return;
         }
+        if(!(block.getBlockData() instanceof Fire)) return;
+
         if(!placedBlocks.contains(block.getLocation())) {
             event.setCancelled(true);
         } else {

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -200,7 +200,7 @@ public class InGameState extends AbstractGameState implements Listener {
         Block block = event.getBlock();
 
         if (!(context.currentState() instanceof InGameState)) return;
-        if (!(block.getBlockData() instanceof Bed)) {
+        if (block.getBlockData() instanceof Bed) {
             List<MetadataValue> metadataValues = block.getMetadata("team");
             if (metadataValues.isEmpty()) return;
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -146,8 +146,10 @@ public class InGameState extends AbstractGameState implements Listener {
             return;
         }
 
-        if (clicked.getType().name().endsWith("_BED")) {
-            event.setCancelled(true);
+        if(!event.getPlayer().isSneaking()) {
+            if (clicked.getType().name().endsWith("_BED")) {
+                event.setCancelled(true);
+            }
         }
     }
 

--- a/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
+++ b/src/main/java/net/alphalightning/bedwars/game/state/states/InGameState.java
@@ -200,7 +200,7 @@ public class InGameState extends AbstractGameState implements Listener {
         Block block = event.getBlock();
 
         if (!(context.currentState() instanceof InGameState)) return;
-        if (block instanceof org.bukkit.block.Bed) {
+        if (block.getState() instanceof Bed) {
             List<MetadataValue> metadataValues = block.getMetadata("team");
             if (metadataValues.isEmpty()) return;
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Diese PR führt eine Map Protection ein. Im Ingame State können keine Blöcke, die nicht von Spielern platziert worden sind (außer Feuer und Betten) von spielern abgebaut werden. Dies beinhaltet auch Explosionen.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes